### PR TITLE
[FEAT] 구글 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### YML ###
+*.yml

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ java {
 	}
 }
 
+jar {
+	enabled = false
+}
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
@@ -29,6 +33,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -36,6 +41,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// JWT
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
 	// Swagger
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'

--- a/src/main/java/depth/main/wishwesee/WishweseeApplication.java
+++ b/src/main/java/depth/main/wishwesee/WishweseeApplication.java
@@ -2,8 +2,10 @@ package depth.main.wishwesee;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class WishweseeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/depth/main/wishwesee/domain/auth/controller/AuthController.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/controller/AuthController.java
@@ -1,0 +1,56 @@
+package depth.main.wishwesee.domain.auth.controller;
+
+import depth.main.wishwesee.domain.auth.dto.req.RefreshTokenReq;
+import depth.main.wishwesee.domain.auth.dto.res.AuthRes;
+import depth.main.wishwesee.domain.auth.service.AuthService;
+import depth.main.wishwesee.global.config.security.token.CurrentUser;
+import depth.main.wishwesee.global.config.security.token.UserPrincipal;
+import depth.main.wishwesee.global.payload.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Authorization", description = "Authorization API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "토큰 갱신", description = "신규 토큰 갱신을 수행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토큰 갱신 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = AuthRes.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "토큰 갱신 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PostMapping(value = "/refresh")
+    public ResponseEntity<?> refresh(
+            @Parameter(description = "Schemas의 RefreshTokenRequest를 참고해주세요.", required = true) @Valid @RequestBody RefreshTokenReq tokenRefreshRequest
+    ) {
+        return authService.refresh(tokenRefreshRequest);
+    }
+
+    @Operation(summary = "로그아웃", description = "사용자가 로그아웃을 수행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "로그아웃 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PostMapping(value="/sign-out")
+    public ResponseEntity<?> signOut(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return authService.signOut(userPrincipal);
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/domain/auth/domain/Token.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/domain/Token.java
@@ -1,0 +1,37 @@
+package depth.main.wishwesee.domain.auth.domain;
+
+import depth.main.wishwesee.domain.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Token extends BaseEntity {
+
+    @Id
+    @Column(name = "user_email" ,nullable = false)
+    private String userEmail;
+
+    @Lob
+    @Column(name = "refresh_token", nullable = false)
+    private String refreshToken;
+
+    public Token updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+        return this;
+    }
+
+    @Builder
+    public Token(String userEmail, String refreshToken) {
+        this.userEmail = userEmail;
+        this.refreshToken = refreshToken;
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/domain/auth/domain/repository/CustomAuthorizationRequestRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/domain/repository/CustomAuthorizationRequestRepository.java
@@ -1,0 +1,51 @@
+package depth.main.wishwesee.domain.auth.domain.repository;
+
+import depth.main.wishwesee.global.config.security.util.CustomCookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Repository;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+
+@Repository
+public class CustomAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+
+    private static final int cookieExpireSeconds = 60*60;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CustomCookie.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CustomCookie.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CustomCookie.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CustomCookie.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            return;
+        }
+
+        CustomCookie.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CustomCookie.serialize(authorizationRequest), cookieExpireSeconds);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CustomCookie.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CustomCookie.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CustomCookie.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/domain/auth/domain/repository/TokenRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/domain/repository/TokenRepository.java
@@ -1,0 +1,15 @@
+package depth.main.wishwesee.domain.auth.domain.repository;
+
+import depth.main.wishwesee.domain.auth.domain.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TokenRepository extends JpaRepository<Token, Long> {
+
+    Optional<Token> findByUserEmail(String userEmail);
+    Optional<Token> findByRefreshToken(String refreshToken);
+
+}

--- a/src/main/java/depth/main/wishwesee/domain/auth/dto/req/RefreshTokenReq.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/dto/req/RefreshTokenReq.java
@@ -1,0 +1,12 @@
+package depth.main.wishwesee.domain.auth.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenReq {
+
+    @Schema( type = "string", example = "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2NTI3OTgxOTh9.6CoxHB_siOuz6PxsxHYQCgUT1_QbdyKTUwStQDutEd1-cIIARbQ0cyrnAmpIgi3IBoLRaqK7N1vXO42nYy4g5g", description="refresh token 입니다." )
+    private String refreshToken;
+
+}

--- a/src/main/java/depth/main/wishwesee/domain/auth/dto/res/AuthRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/dto/res/AuthRes.java
@@ -1,0 +1,27 @@
+package depth.main.wishwesee.domain.auth.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AuthRes {
+
+    @Schema( type = "string", example = "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2NTI3OTgxOTh9.6CoxHB_siOuz6PxsxHYQCgUT1_QbdyKTUwStQDutEd1-cIIARbQ0cyrnAmpIgi3IBoLRaqK7N1vXO42nYy4g5g" , description="액세스 토큰을 출력합니다.")
+    private String accessToken;
+
+    @Schema( type = "string", example = "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2NTI3OTgxOTh9.asdf8as4df865as4dfasdf65_asdfweioufsdoiuf_432jdsaFEWFSDV_sadf" , description="리프레시 토큰을 출력합니다.")
+    private String refreshToken;
+
+    @Schema( type = "string", example ="Bearer", description="권한(Authorization) 값 해더의 명칭을 지정합니다.")
+    private String tokenType = "Bearer";
+
+    @Builder
+    public AuthRes(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/domain/auth/dto/res/TokenMapping.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/dto/res/TokenMapping.java
@@ -1,0 +1,16 @@
+package depth.main.wishwesee.domain.auth.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class TokenMapping {
+    private String email;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/depth/main/wishwesee/domain/auth/exception/InvalidTokenException.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/exception/InvalidTokenException.java
@@ -1,0 +1,9 @@
+package depth.main.wishwesee.domain.auth.exception;
+
+public class InvalidTokenException extends RuntimeException {
+
+    public InvalidTokenException() {
+        super("이미 로그아웃 된 유저입니다.");
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/domain/auth/service/AuthService.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/service/AuthService.java
@@ -1,0 +1,93 @@
+package depth.main.wishwesee.domain.auth.service;
+
+import depth.main.wishwesee.domain.auth.domain.Token;
+import depth.main.wishwesee.domain.auth.dto.res.AuthRes;
+import depth.main.wishwesee.domain.auth.exception.InvalidTokenException;
+import depth.main.wishwesee.domain.auth.domain.repository.TokenRepository;
+import depth.main.wishwesee.domain.auth.dto.req.RefreshTokenReq;
+import depth.main.wishwesee.domain.auth.dto.res.TokenMapping;
+import depth.main.wishwesee.domain.user.domain.repository.UserRepository;
+import depth.main.wishwesee.global.DefaultAssert;
+import depth.main.wishwesee.global.config.security.token.UserPrincipal;
+import depth.main.wishwesee.global.payload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final CustomTokenProviderService customTokenProviderService;
+    private final AuthenticationManager authenticationManager;
+
+    private final TokenRepository tokenRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ResponseEntity<ApiResponse> refresh(RefreshTokenReq tokenRefreshRequest){
+        boolean checkValid = valid(tokenRefreshRequest.getRefreshToken());
+        DefaultAssert.isAuthentication(checkValid);
+
+        Token token = tokenRepository.findByRefreshToken(tokenRefreshRequest.getRefreshToken())
+                .orElseThrow(InvalidTokenException::new);
+        Authentication authentication = customTokenProviderService.getAuthenticationByEmail(token.getUserEmail());
+
+        TokenMapping tokenMapping;
+
+        Long expirationTime = customTokenProviderService.getExpiration(tokenRefreshRequest.getRefreshToken());
+        if(expirationTime > 0){
+            tokenMapping = customTokenProviderService.refreshToken(authentication, token.getRefreshToken());
+        }else{
+            tokenMapping = customTokenProviderService.createToken(authentication);
+        }
+
+        Token updateToken = token.updateRefreshToken(tokenMapping.getRefreshToken());
+
+        AuthRes authResponse = AuthRes.builder()
+                .accessToken(tokenMapping.getAccessToken())
+                .refreshToken(updateToken.getRefreshToken())
+                .build();
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(authResponse)
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @Transactional
+    public ResponseEntity<?> signOut(UserPrincipal userPrincipal){
+        Token token = tokenRepository.findByUserEmail(userPrincipal.getEmail())
+                .orElseThrow(InvalidTokenException::new);
+
+        tokenRepository.delete(token);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information("유저가 로그아웃 되었습니다.")
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    private boolean valid(String refreshToken){
+        boolean validateCheck = customTokenProviderService.validateToken(refreshToken);
+        DefaultAssert.isTrue(validateCheck, "Token 검증에 실패하였습니다.");
+
+        Optional<Token> token = tokenRepository.findByRefreshToken(refreshToken);
+        DefaultAssert.isTrue(token.isPresent(), "탈퇴 처리된 회원입니다.");
+
+        Authentication authentication = customTokenProviderService.getAuthenticationByEmail(token.get().getUserEmail());
+        DefaultAssert.isTrue(token.get().getUserEmail().equals(authentication.getName()), "사용자 인증에 실패하였습니다.");
+
+        return true;
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/domain/auth/service/CustomDefaultOAuth2UserService.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/service/CustomDefaultOAuth2UserService.java
@@ -1,0 +1,82 @@
+package depth.main.wishwesee.domain.auth.service;
+
+import depth.main.wishwesee.domain.user.domain.Provider;
+import depth.main.wishwesee.domain.user.domain.Role;
+import depth.main.wishwesee.domain.user.domain.User;
+import depth.main.wishwesee.domain.user.domain.repository.UserRepository;
+import depth.main.wishwesee.global.DefaultAssert;
+import depth.main.wishwesee.global.config.security.auth.OAuth2UserInfo;
+import depth.main.wishwesee.global.config.security.auth.OAuth2UserInfoFactory;
+import depth.main.wishwesee.global.config.security.token.UserPrincipal;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CustomDefaultOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(oAuth2UserRequest);
+        try {
+            return processOAuth2User(oAuth2UserRequest, oAuth2User);
+        } catch (Exception e) {
+            log.error("Error processing OAuth2 user: {}", e.getMessage(), e);
+            DefaultAssert.isAuthentication(e.getMessage());
+        }
+        return null;
+    }
+
+    private OAuth2User processOAuth2User(OAuth2UserRequest oAuth2UserRequest, OAuth2User oAuth2User) {
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(oAuth2UserRequest.getClientRegistration().getRegistrationId(), oAuth2User.getAttributes());
+        DefaultAssert.isAuthentication(!oAuth2UserInfo.getEmail().isEmpty());
+
+        Optional<User> userOptional = userRepository.findByEmail(oAuth2UserInfo.getEmail());
+        User user;
+        if(userOptional.isPresent()) {
+            user = userOptional.get();
+            DefaultAssert.isAuthentication(user.getProvider().equals(Provider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId())));
+        } else {
+            user = registerNewUser(oAuth2UserRequest, oAuth2UserInfo);
+        }
+        return UserPrincipal.create(user, oAuth2User.getAttributes());
+    }
+
+    private User registerNewUser(OAuth2UserRequest oAuth2UserRequest, OAuth2UserInfo oAuth2UserInfo) {
+        User user = User.builder()
+                .provider(Provider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId()))
+                .providerId(oAuth2UserInfo.getId())
+                .email(oAuth2UserInfo.getEmail())
+                .name(oAuth2UserInfo.getName())
+                .profile(oAuth2UserInfo.getImageUrl())
+                .password(encodePassword(oAuth2UserInfo.getId()))
+                .role(Role.USER)
+                .build();
+        User savedUser = userRepository.save(user);
+        return savedUser;
+    }
+
+    private String encodePassword(String password) {
+        return customPasswordEncoder().encode(password);
+    }
+
+    @Bean
+    public PasswordEncoder customPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/domain/auth/service/CustomTokenProviderService.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/service/CustomTokenProviderService.java
@@ -1,0 +1,130 @@
+package depth.main.wishwesee.domain.auth.service;
+
+import depth.main.wishwesee.domain.auth.dto.res.TokenMapping;
+import depth.main.wishwesee.global.config.security.OAuth2Config;
+import depth.main.wishwesee.global.config.security.token.UserPrincipal;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CustomTokenProviderService {
+
+    private final OAuth2Config oAuth2Config;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    public TokenMapping refreshToken(Authentication authentication, String refreshToken) {
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+        Date now = new Date();
+
+        Date accessTokenExpiresIn = new Date(now.getTime() + oAuth2Config.getAuth().getAccessTokenExpirationMsec());
+
+        String secretKey = oAuth2Config.getAuth().getTokenSecret();
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        Key key = Keys.hmacShaKeyFor(keyBytes);
+
+        String accessToken = Jwts.builder()
+                .setSubject(userPrincipal.getEmail())
+                .setIssuedAt(new Date())
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return TokenMapping.builder()
+                .email(userPrincipal.getEmail())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public TokenMapping createToken(Authentication authentication) {
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+
+        Date now = new Date();
+
+        Date accessTokenExpiresIn = new Date(now.getTime() + oAuth2Config.getAuth().getAccessTokenExpirationMsec());
+        Date refreshTokenExpiresIn = new Date(now.getTime() + oAuth2Config.getAuth().getRefreshTokenExpirationMsec());
+
+        String secretKey = oAuth2Config.getAuth().getTokenSecret();
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        Key key = Keys.hmacShaKeyFor(keyBytes);
+
+        String accessToken = Jwts.builder()
+                .setSubject(userPrincipal.getEmail())
+                .setIssuedAt(new Date())
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setExpiration(refreshTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return TokenMapping.builder()
+                .email(userPrincipal.getEmail())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public String getEmailFromToken(String token) {
+        log.debug("Extracting email from token: {}", token);  // 추가된 로깅
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(oAuth2Config.getAuth().getTokenSecret())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        String email = claims.getSubject();
+        log.debug("Email extracted: {}", email);  // 추가된 로깅
+        return email;
+    }
+
+    public UsernamePasswordAuthenticationToken getAuthenticationByEmail(String token) {
+        String email = getEmailFromToken(token);
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    public Long getExpiration(String token) {
+        // accessToken 남은 유효시간
+        Date expiration = Jwts.parserBuilder()
+                .setSigningKey(oAuth2Config.getAuth().getTokenSecret())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+        // 현재 시간
+        Long now = new Date().getTime();
+        // 시간 계산
+        return (expiration.getTime() - now);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(oAuth2Config.getAuth().getTokenSecret()).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException ex) {
+            log.error("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException ex) {
+            log.error("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException ex) {
+            log.error("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException ex) {
+            log.error("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+}

--- a/src/main/java/depth/main/wishwesee/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,35 @@
+package depth.main.wishwesee.domain.auth.service;
+
+import depth.main.wishwesee.domain.user.domain.User;
+import depth.main.wishwesee.domain.user.domain.repository.UserRepository;
+import depth.main.wishwesee.global.DefaultAssert;
+import depth.main.wishwesee.global.config.security.token.UserPrincipal;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import java.util.Optional;
+
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("유저 정보를 찾을 수 없습니다."));
+        return UserPrincipal.create(user);
+    }
+
+    @Transactional
+    public UserDetails loadUserById(Long id) {
+        Optional<User> user = userRepository.findById(id);
+        DefaultAssert.isOptionalPresent(user);
+        return UserPrincipal.create(user.get());
+    }
+}

--- a/src/main/java/depth/main/wishwesee/domain/user/domain/Provider.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/domain/Provider.java
@@ -1,0 +1,7 @@
+package depth.main.wishwesee.domain.user.domain;
+
+public enum Provider {
+    google,
+    kakao,
+    naver;
+}

--- a/src/main/java/depth/main/wishwesee/domain/user/domain/Role.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/domain/Role.java
@@ -1,0 +1,13 @@
+package depth.main.wishwesee.domain.user.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum Role {
+    ADMIN("ROLE_ADMIN"),
+    USER("ROLE_USER");
+
+    private String value;
+}

--- a/src/main/java/depth/main/wishwesee/domain/user/domain/User.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/domain/User.java
@@ -2,23 +2,34 @@ package depth.main.wishwesee.domain.user.domain;
 
 import depth.main.wishwesee.domain.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
+@Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
 
+    private String email;
+
+    private String password;
+
     private String name;
 
     private String profile;
 
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
     private String providerId;
 
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
 }
 

--- a/src/main/java/depth/main/wishwesee/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/domain/repository/UserRepository.java
@@ -3,5 +3,8 @@ package depth.main.wishwesee.domain.user.domain.repository;
 import depth.main.wishwesee.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User,Long> {
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/depth/main/wishwesee/global/DefaultAssert.java
+++ b/src/main/java/depth/main/wishwesee/global/DefaultAssert.java
@@ -1,0 +1,54 @@
+package depth.main.wishwesee.global;
+
+import depth.main.wishwesee.global.exception.DefaultAuthenticationException;
+import depth.main.wishwesee.global.exception.DefaultException;
+import depth.main.wishwesee.global.payload.ErrorCode;
+import org.springframework.util.Assert;
+
+import java.util.List;
+import java.util.Optional;
+
+public class DefaultAssert extends Assert {
+
+    public static void isTrue(boolean value){
+        if(!value){
+            throw new DefaultException(ErrorCode.INVALID_CHECK);
+        }
+    }
+
+    public static void isTrue(boolean value, String message){
+        if(!value){
+            throw new DefaultException(ErrorCode.INVALID_CHECK, message);
+        }
+    }
+
+
+    public static void isListNull(List<Object> values){
+        if(values.isEmpty()){
+            throw new DefaultException(ErrorCode.INVALID_FILE_PATH);
+        }
+    }
+
+    public static void isListNull(Object[] values){
+        if(values == null){
+            throw new DefaultException(ErrorCode.INVALID_FILE_PATH);
+        }
+    }
+
+    public static void isOptionalPresent(Optional<?> value){
+        if(!value.isPresent()){
+            throw new DefaultException(ErrorCode.INVALID_PARAMETER);
+        }
+    }
+
+    public static void isAuthentication(String message){
+        throw new DefaultAuthenticationException(message);
+    }
+
+    public static void isAuthentication(boolean value){
+        if(!value){
+            throw new DefaultAuthenticationException(ErrorCode.INVALID_AUTHENTICATION);
+        }
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/global/config/security/OAuth2Config.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/OAuth2Config.java
@@ -1,0 +1,41 @@
+package depth.main.wishwesee.global.config.security;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@ConfigurationProperties(prefix = "app")
+@Getter
+public class OAuth2Config {
+    private final Auth auth = new Auth();
+    private final OAuth2 oauth2 = new OAuth2();
+
+    @Getter
+    @Setter
+    public static class Auth {
+        private String tokenSecret;
+        private long accessTokenExpirationMsec;
+        private long refreshTokenExpirationMsec;
+    }
+
+    @Getter
+    @Setter
+    public static final class OAuth2 {
+        private List<String> authorizedRedirectUris = new ArrayList<>();
+
+        public List<String> getAuthorizedRedirectUris() {
+            return authorizedRedirectUris;
+        }
+
+        public OAuth2 authorizedRedirectUris(List<String> authorizedRedirectUris) {
+            this.authorizedRedirectUris = authorizedRedirectUris;
+            return this;
+        }
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/global/config/security/SecurityConfig.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/SecurityConfig.java
@@ -1,26 +1,108 @@
 package depth.main.wishwesee.global.config.security;
 
+import depth.main.wishwesee.domain.auth.domain.repository.CustomAuthorizationRequestRepository;
+import depth.main.wishwesee.domain.auth.service.CustomDefaultOAuth2UserService;
+import depth.main.wishwesee.domain.auth.service.CustomUserDetailsService;
+import depth.main.wishwesee.global.config.security.handler.CustomSimpleUrlAuthenticationFailureHandler;
+import depth.main.wishwesee.global.config.security.handler.CustomSimpleUrlAuthenticationSuccessHandler;
+import depth.main.wishwesee.global.config.security.token.CustomAuthenticationEntryPoint;
+import depth.main.wishwesee.global.config.security.token.CustomOncePerRequestFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final CustomDefaultOAuth2UserService customOAuth2UserService;
+    private final CustomSimpleUrlAuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final CustomSimpleUrlAuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+    private final CustomAuthorizationRequestRepository customAuthorizationRequestRepository;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CustomOncePerRequestFilter customOncePerRequestFilter() {
+        return new CustomOncePerRequestFilter();
+    }
+
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
+
+        authenticationProvider.setUserDetailsService(customUserDetailsService);
+        authenticationProvider.setPasswordEncoder(passwordEncoder());
+
+        return authenticationProvider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of(
+                "http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable);
-        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exception -> exception.authenticationEntryPoint(new CustomAuthenticationEntryPoint()))
                 .authorizeHttpRequests(
                         authorize -> authorize
-                                .requestMatchers("").permitAll()
-                                .requestMatchers("").permitAll()
+                                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                                .requestMatchers("/auth/**").permitAll()
                                 .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(authorization -> authorization
+                                .baseUri("/oauth2/authorize")
+                                .authorizationRequestRepository(customAuthorizationRequestRepository))
+                        .redirectionEndpoint(redirection -> redirection
+                                .baseUri("/oauth2/callback/**"))
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
+                        .failureHandler(oAuth2AuthenticationFailureHandler)
                 );
+
         return http.build();
     }
 }

--- a/src/main/java/depth/main/wishwesee/global/config/security/auth/OAuth2UserInfo.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/auth/OAuth2UserInfo.java
@@ -1,0 +1,25 @@
+package depth.main.wishwesee.global.config.security.auth;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public abstract String getProvider();
+
+    public abstract String getId();
+
+    public abstract String getName();
+
+    public abstract String getEmail();
+
+    public abstract String getImageUrl();
+}

--- a/src/main/java/depth/main/wishwesee/global/config/security/auth/OAuth2UserInfoFactory.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/auth/OAuth2UserInfoFactory.java
@@ -1,0 +1,18 @@
+package depth.main.wishwesee.global.config.security.auth;
+
+import depth.main.wishwesee.domain.user.domain.Provider;
+import depth.main.wishwesee.global.DefaultAssert;
+import depth.main.wishwesee.global.config.security.auth.company.Google;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+    public static OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+        if(registrationId.equalsIgnoreCase(Provider.google.toString())) {
+            return new Google(attributes);
+        } else {
+            DefaultAssert.isAuthentication("해당 oauth2 기능은 지원하지 않습니다.");
+        }
+        return null;
+    }
+}

--- a/src/main/java/depth/main/wishwesee/global/config/security/auth/company/Google.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/auth/company/Google.java
@@ -1,0 +1,38 @@
+package depth.main.wishwesee.global.config.security.auth.company;
+
+import depth.main.wishwesee.domain.user.domain.Provider;
+import depth.main.wishwesee.global.config.security.auth.OAuth2UserInfo;
+
+import java.util.Map;
+
+public class Google extends OAuth2UserInfo {
+
+    public Google(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+
+    @Override
+    public String getProvider(){
+        return Provider.google.toString();
+    }
+}

--- a/src/main/java/depth/main/wishwesee/global/config/security/handler/CustomSimpleUrlAuthenticationFailureHandler.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/handler/CustomSimpleUrlAuthenticationFailureHandler.java
@@ -1,0 +1,39 @@
+package depth.main.wishwesee.global.config.security.handler;
+
+import depth.main.wishwesee.domain.auth.domain.repository.CustomAuthorizationRequestRepository;
+import depth.main.wishwesee.global.config.security.util.CustomCookie;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+import static depth.main.wishwesee.domain.auth.domain.repository.CustomAuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
+
+@RequiredArgsConstructor
+@Component
+public class CustomSimpleUrlAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    private final CustomAuthorizationRequestRepository customAuthorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        String targetUrl = CustomCookie.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue)
+                .orElse(("/"));
+
+        targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("error", exception.getLocalizedMessage())
+                .build().toUriString();
+
+        customAuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/depth/main/wishwesee/global/config/security/handler/CustomSimpleUrlAuthenticationSuccessHandler.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/handler/CustomSimpleUrlAuthenticationSuccessHandler.java
@@ -1,0 +1,88 @@
+package depth.main.wishwesee.global.config.security.handler;
+
+import depth.main.wishwesee.domain.auth.domain.Token;
+import depth.main.wishwesee.domain.auth.domain.repository.CustomAuthorizationRequestRepository;
+import depth.main.wishwesee.domain.auth.domain.repository.TokenRepository;
+import depth.main.wishwesee.domain.auth.dto.res.TokenMapping;
+import depth.main.wishwesee.domain.auth.service.CustomTokenProviderService;
+import depth.main.wishwesee.global.DefaultAssert;
+import depth.main.wishwesee.global.config.security.OAuth2Config;
+import depth.main.wishwesee.global.config.security.util.CustomCookie;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+
+import static depth.main.wishwesee.domain.auth.domain.repository.CustomAuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
+@RequiredArgsConstructor
+@Component
+public class CustomSimpleUrlAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final CustomTokenProviderService customTokenProviderService;
+    private final OAuth2Config oAuth2Config;
+    private final TokenRepository tokenRepository;
+    private final CustomAuthorizationRequestRepository customAuthorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        DefaultAssert.isAuthentication(!response.isCommitted());
+
+        String targetUrl = determineTargetUrl(request, response, authentication);
+
+        TokenMapping token = customTokenProviderService.createToken(authentication);
+        CustomCookie.addCookie(response, "Authorization", "Bearer_" + token.getAccessToken(), (int) oAuth2Config.getAuth().getAccessTokenExpirationMsec());
+        CustomCookie.addCookie(response, "Refresh_Token", "Bearer_" + token.getRefreshToken(), (int) oAuth2Config.getAuth().getRefreshTokenExpirationMsec());
+
+        clearAuthenticationAttributes(request, response);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        Optional<String> redirectUri = CustomCookie.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME).map(Cookie::getValue);
+
+        DefaultAssert.isAuthentication( !(redirectUri.isPresent() && !isAuthorizedRedirectUri(redirectUri.get())) );
+
+        String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
+
+        TokenMapping tokenMapping = customTokenProviderService.createToken(authentication);
+        Token token = Token.builder()
+                .userEmail(tokenMapping.getEmail())
+                .refreshToken(tokenMapping.getRefreshToken())
+                .build();
+        tokenRepository.save(token);
+
+        return UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("token", tokenMapping.getAccessToken())
+                .build().toUriString();
+    }
+
+    protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+        super.clearAuthenticationAttributes(request);
+        customAuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+
+    private boolean isAuthorizedRedirectUri(String uri) {
+        URI clientRedirectUri = URI.create(uri);
+
+        return oAuth2Config.getOauth2().getAuthorizedRedirectUris()
+                .stream()
+                .anyMatch(authorizedRedirectUri -> {
+                    URI authorizedURI = URI.create(authorizedRedirectUri);
+                    if(authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+                            && authorizedURI.getPort() == clientRedirectUri.getPort()) {
+                        return true;
+                    }
+                    return false;
+                });
+    }
+}

--- a/src/main/java/depth/main/wishwesee/global/config/security/token/CurrentUser.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/token/CurrentUser.java
@@ -1,0 +1,13 @@
+package depth.main.wishwesee.global.config.security.token;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal
+public @interface CurrentUser {
+
+}

--- a/src/main/java/depth/main/wishwesee/global/config/security/token/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/token/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package depth.main.wishwesee.global.config.security.token;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getLocalizedMessage());
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/global/config/security/token/CustomOncePerRequestFilter.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/token/CustomOncePerRequestFilter.java
@@ -1,0 +1,46 @@
+package depth.main.wishwesee.global.config.security.token;
+
+import depth.main.wishwesee.domain.auth.service.CustomTokenProviderService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CustomOncePerRequestFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private CustomTokenProviderService customTokenProviderService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String jwt = getJwtFromRequest(request);
+
+        if (StringUtils.hasText(jwt) && customTokenProviderService.validateToken(jwt)) {
+            UsernamePasswordAuthenticationToken authentication = customTokenProviderService.getAuthenticationByEmail(jwt);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            log.info("bearerToken = {}", bearerToken.substring(7));
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/depth/main/wishwesee/global/config/security/token/UserPrincipal.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/token/UserPrincipal.java
@@ -1,0 +1,102 @@
+package depth.main.wishwesee.global.config.security.token;
+
+import depth.main.wishwesee.domain.user.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class UserPrincipal implements OAuth2User, UserDetails {
+
+    private Long id;
+    private String email;
+    private String password;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    public UserPrincipal(Long id, String email, String password, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.authorities = authorities;
+    }
+
+    public static UserPrincipal create(User user) {
+        List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(user.getRole().getValue()));
+        return new UserPrincipal(
+                user.getId(),
+                user.getEmail(),
+                user.getPassword(),
+                authorities
+        );
+    }
+
+    public static UserPrincipal create(User user, Map<String, Object> attributes) {
+        UserPrincipal userPrincipal = UserPrincipal.create(user);
+        userPrincipal.setAttributes(attributes);
+        return userPrincipal;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(id);
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/global/config/security/util/CustomCookie.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/util/CustomCookie.java
@@ -1,0 +1,58 @@
+package depth.main.wishwesee.global.config.security.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.util.SerializationUtils;
+
+import java.util.Base64;
+import java.util.Optional;
+
+public class CustomCookie {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name){
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie: cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/src/main/java/depth/main/wishwesee/global/exception/DefaultAuthenticationException.java
+++ b/src/main/java/depth/main/wishwesee/global/exception/DefaultAuthenticationException.java
@@ -1,0 +1,26 @@
+package depth.main.wishwesee.global.exception;
+
+import depth.main.wishwesee.global.payload.ErrorCode;
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class DefaultAuthenticationException extends AuthenticationException {
+
+    private ErrorCode errorCode;
+
+    public DefaultAuthenticationException(String msg, Throwable t) {
+        super(msg, t);
+        this.errorCode = ErrorCode.INVALID_REPRESENTATION;
+    }
+
+    public DefaultAuthenticationException(String msg) {
+        super(msg);
+    }
+
+    public DefaultAuthenticationException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/global/exception/DefaultException.java
+++ b/src/main/java/depth/main/wishwesee/global/exception/DefaultException.java
@@ -1,0 +1,21 @@
+package depth.main.wishwesee.global.exception;
+
+import depth.main.wishwesee.global.payload.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class DefaultException extends RuntimeException{
+
+    private ErrorCode errorCode;
+
+    public DefaultException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public DefaultException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/global/exception/NotFoundException.java
+++ b/src/main/java/depth/main/wishwesee/global/exception/NotFoundException.java
@@ -1,0 +1,17 @@
+package depth.main.wishwesee.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class NotFoundException extends RuntimeException {
+    private final int statusCode;
+    private final String code;
+    private final String message;
+
+    public NotFoundException(String code, String message) {
+        super(message);
+        this.statusCode = 404;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/depth/main/wishwesee/global/payload/ApiResponse.java
+++ b/src/main/java/depth/main/wishwesee/global/payload/ApiResponse.java
@@ -1,0 +1,26 @@
+package depth.main.wishwesee.global.payload;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ApiResponse {
+
+    @Schema( type = "boolean", example = "true", description="올바르게 로직을 처리했으면 True, 아니면 False를 반환합니다.")
+    private boolean check;
+
+    @Schema( type = "object", example = "information", description="restful의 정보를 감싸 표현합니다. object형식으로 표현합니다.")
+    private Object information;
+
+    public ApiResponse(){};
+
+    @Builder
+    public ApiResponse(boolean check, Object information) {
+        this.check = check;
+        this.information = information;
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/global/payload/ErrorCode.java
+++ b/src/main/java/depth/main/wishwesee/global/payload/ErrorCode.java
@@ -1,0 +1,28 @@
+package depth.main.wishwesee.global.payload;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    INVALID_PARAMETER(400, "E001", "잘못된 요청 데이터 입니다."),
+    INVALID_REPRESENTATION(400, "E002", "잘못된 표현 입니다."),
+    INVALID_FILE_PATH(400, "E003", "잘못된 파일 경로 입니다."),
+    INVALID_OPTIONAL_ISPRESENT(400, "E004", "해당 값이 존재하지 않습니다."),
+    INVALID_CHECK(400, "E005", "해당 값이 유효하지 않습니다."),
+    INVALID_AUTHENTICATION(400, "E006", "잘못된 인증입니다."),
+    INVALID_TOKEN(400, "E007", "잘못된 토큰입니다."),
+    NOT_FOUND(404, "E008", "해당 데이터를 찾을 수 없습니다."),
+    DUPLICATE_ERROR(409, "E009", "중복된 데이터가 존재합니다.");
+
+    private final String code;
+    private final String message;
+    private final int status;
+
+    ErrorCode(final int status, final String code, final String message) {
+        this.status = status;
+        this.message = message;
+        this.code = code;
+    }
+
+}

--- a/src/main/java/depth/main/wishwesee/global/payload/ErrorResponse.java
+++ b/src/main/java/depth/main/wishwesee/global/payload/ErrorResponse.java
@@ -1,0 +1,40 @@
+package depth.main.wishwesee.global.payload;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+
+
+    private String message;
+    private int status;
+    private String code;
+
+
+    @Builder
+    private ErrorResponse(final ErrorCode code) {
+        this.status = code.getStatus();
+        this.message = code.getMessage();
+        this.code = code.getCode();
+    }
+
+    private ErrorResponse(final ErrorCode code, final String message) {
+        this.status = code.getStatus();
+        this.message = message;
+        this.code = code.getCode();
+
+    }
+
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final String message) {
+        return new ErrorResponse(code, message);
+
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=wishwesee


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- 구글 로그인 구현 및 로그아웃, 리프레시 구현


## 💬리뷰 요구사항(선택)
> 리뷰어가 신경써서 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- auth/service 폴더 내 `CustomDefaultOAuth2UserService` 중
```
private String encodePassword(String password) {
        return customPasswordEncoder().encode(password);
    }

@Bean
public PasswordEncoder customPasswordEncoder() {
        return new BCryptPasswordEncoder();
    }
```
에서 에러 발생해도 무시해주시면 됩니다! 실행에는 문제없어요
발생 사유: 해당 부분에도 passwordEncoder가 필요한데 직접 주입 시 securityConfig와 순환참조가 발생합니다.. 
- yml 파일 노션에 추가해두었습니다! 확인해주시고 반영해주세용

## ✅Check
- [x] 각 기능에 대한 테스트
- [x] label
- [x] develop branch pull



## #️⃣연관된 이슈
> ex) #이슈번호
- resolve #1 


## 💡References(선택)
> 작업하면서 참고한 레퍼런스가 있다면 첨부해주세요
- 
