### PR TITLE
[FEAT] 초대장 후기 API 구현

### DIFF
--- a/src/main/java/depth/main/wishwesee/domain/auth/controller/AuthController.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/controller/AuthController.java
@@ -1,7 +1,7 @@
 package depth.main.wishwesee.domain.auth.controller;
 
-import depth.main.wishwesee.domain.auth.dto.req.RefreshTokenReq;
-import depth.main.wishwesee.domain.auth.dto.res.AuthRes;
+import depth.main.wishwesee.domain.auth.dto.request.RefreshTokenReq;
+import depth.main.wishwesee.domain.auth.dto.response.AuthRes;
 import depth.main.wishwesee.domain.auth.service.AuthService;
 import depth.main.wishwesee.global.config.security.token.CurrentUser;
 import depth.main.wishwesee.global.config.security.token.UserPrincipal;

--- a/src/main/java/depth/main/wishwesee/domain/auth/dto/request/RefreshTokenReq.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/dto/request/RefreshTokenReq.java
@@ -1,4 +1,4 @@
-package depth.main.wishwesee.domain.auth.dto.req;
+package depth.main.wishwesee.domain.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;

--- a/src/main/java/depth/main/wishwesee/domain/auth/dto/response/AuthRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/dto/response/AuthRes.java
@@ -1,4 +1,4 @@
-package depth.main.wishwesee.domain.auth.dto.res;
+package depth.main.wishwesee.domain.auth.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;

--- a/src/main/java/depth/main/wishwesee/domain/auth/dto/response/TokenMapping.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/dto/response/TokenMapping.java
@@ -1,4 +1,4 @@
-package depth.main.wishwesee.domain.auth.dto.res;
+package depth.main.wishwesee.domain.auth.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/depth/main/wishwesee/domain/auth/service/AuthService.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/service/AuthService.java
@@ -1,11 +1,11 @@
 package depth.main.wishwesee.domain.auth.service;
 
 import depth.main.wishwesee.domain.auth.domain.Token;
-import depth.main.wishwesee.domain.auth.dto.res.AuthRes;
+import depth.main.wishwesee.domain.auth.dto.response.AuthRes;
 import depth.main.wishwesee.domain.auth.exception.InvalidTokenException;
 import depth.main.wishwesee.domain.auth.domain.repository.TokenRepository;
-import depth.main.wishwesee.domain.auth.dto.req.RefreshTokenReq;
-import depth.main.wishwesee.domain.auth.dto.res.TokenMapping;
+import depth.main.wishwesee.domain.auth.dto.request.RefreshTokenReq;
+import depth.main.wishwesee.domain.auth.dto.response.TokenMapping;
 import depth.main.wishwesee.domain.user.domain.repository.UserRepository;
 import depth.main.wishwesee.global.DefaultAssert;
 import depth.main.wishwesee.global.config.security.token.UserPrincipal;

--- a/src/main/java/depth/main/wishwesee/domain/auth/service/CustomTokenProviderService.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/service/CustomTokenProviderService.java
@@ -1,6 +1,6 @@
 package depth.main.wishwesee.domain.auth.service;
 
-import depth.main.wishwesee.domain.auth.dto.res.TokenMapping;
+import depth.main.wishwesee.domain.auth.dto.response.TokenMapping;
 import depth.main.wishwesee.global.config.security.OAuth2Config;
 import depth.main.wishwesee.global.config.security.token.UserPrincipal;
 import io.jsonwebtoken.*;

--- a/src/main/java/depth/main/wishwesee/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/service/CustomUserDetailsService.java
@@ -29,7 +29,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Transactional
     public UserDetails loadUserById(Long id) {
         Optional<User> user = userRepository.findById(id);
-        DefaultAssert.isOptionalPresent(user);
+        DefaultAssert.isOptionalPresent(user, "사용자를 찾을 수 없습니다.");
         return UserPrincipal.create(user.get());
     }
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -66,8 +66,8 @@ public class InvitationController {
     public ResponseEntity<Void> saveFeedback(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "초대장의 id를 입력해주세요.", required = true) @PathVariable Long invitationId,
-            @Parameter(description = "후기 이미지입니다. 1장만 입력 가능합니다.") @RequestPart Optional<MultipartFile> image,
-            @Parameter(description = "Schemas의 CreateFeedbackReq를 확인해주세요. 후기에 들어갈 내용입니다.") @RequestPart CreateFeedbackReq createFeedbackReq
+            @Parameter(description = "후기 이미지입니다. 1장만 입력 가능합니다.") @RequestPart(required = false) MultipartFile image,
+            @Parameter(description = "Schemas의 CreateFeedbackReq를 확인해주세요. 후기에 들어갈 내용입니다.") @RequestPart(required = false) CreateFeedbackReq createFeedbackReq
     ) {
         return feedbackService.saveFeedback(userPrincipal, invitationId, image, createFeedbackReq);
     }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -1,11 +1,45 @@
 package depth.main.wishwesee.domain.invitation.controller;
 
+import depth.main.wishwesee.domain.auth.dto.res.AuthRes;
+import depth.main.wishwesee.domain.invitation.dto.req.CreateFeedbackReq;
+import depth.main.wishwesee.domain.invitation.service.FeedbackService;
+import depth.main.wishwesee.global.config.security.token.CurrentUser;
+import depth.main.wishwesee.global.config.security.token.UserPrincipal;
+import depth.main.wishwesee.global.payload.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/invitation")
 public class InvitationController {
+
+    private final FeedbackService feedbackService;
+
+    @Operation(summary = "후기 작성", description = "내가 받은/보낸 초대장의 후기를 작성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "후기 등록 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Void.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "후기 등록 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @PostMapping(value = "/{receivedInvitationId}/feedback")
+    public ResponseEntity<?> saveFeedback(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "받은 초대장의 id를 입력해주세요.", required = true) @PathVariable Long receivedInvitationId,
+            @Parameter(description = "후기 이미지입니다. 1장만 입력 가능합니다.") @RequestPart Optional<MultipartFile> image,
+            @Parameter(description = "Schemas의 CreateFeedbackReq를 확인해주세요. 후기에 들어갈 내용입니다.") @RequestPart CreateFeedbackReq createFeedbackReq
+    ) {
+        feedbackService.saveFeedback(userPrincipal, receivedInvitationId, image, createFeedbackReq);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -1,6 +1,6 @@
 package depth.main.wishwesee.domain.invitation.controller;
 
-import depth.main.wishwesee.domain.invitation.dto.req.CreateFeedbackReq;
+import depth.main.wishwesee.domain.invitation.dto.request.CreateFeedbackReq;
 import depth.main.wishwesee.domain.invitation.dto.request.InvitationReq;
 import depth.main.wishwesee.domain.invitation.service.FeedbackService;
 import depth.main.wishwesee.global.config.security.token.CurrentUser;
@@ -20,7 +20,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.net.URI;
 import java.util.Optional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -85,4 +85,18 @@ public class InvitationController {
         return feedbackService.getFeedbacks(userPrincipal, invitationId);
     }
 
+    @Operation(summary = "후기 삭제", description = "내가 받은/보낸 초대장의 후기를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "후기 삭제 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Void.class))}),
+            @ApiResponse(responseCode = "400", description = "후기 삭제 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @DeleteMapping ("/{invitationId}/feedback/{feedbackId}")
+    public ResponseEntity<Void> deleteFeedback(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "초대장의 id를 입력해주세요.", required = true) @PathVariable Long invitationId,
+            @Parameter(description = "후기의 id를 입력해주세요.", required = true) @PathVariable Long feedbackId
+    ) {
+        return feedbackService.deleteFeedback(userPrincipal, invitationId, feedbackId);
+    }
+
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -62,14 +62,14 @@ public class InvitationController {
             @ApiResponse(responseCode = "200", description = "후기 등록 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Void.class) ) } ),
             @ApiResponse(responseCode = "400", description = "후기 등록 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @PostMapping(value = "/{receivedInvitationId}/feedback")
+    @PostMapping(value = "/{invitationId}/feedback")
     public ResponseEntity<Void> saveFeedback(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "받은 초대장의 id를 입력해주세요.", required = true) @PathVariable Long receivedInvitationId,
+            @Parameter(description = "초대장의 id를 입력해주세요.", required = true) @PathVariable Long invitationId,
             @Parameter(description = "후기 이미지입니다. 1장만 입력 가능합니다.") @RequestPart Optional<MultipartFile> image,
             @Parameter(description = "Schemas의 CreateFeedbackReq를 확인해주세요. 후기에 들어갈 내용입니다.") @RequestPart CreateFeedbackReq createFeedbackReq
     ) {
-        return feedbackService.saveFeedback(userPrincipal, receivedInvitationId, image, createFeedbackReq);
+        return feedbackService.saveFeedback(userPrincipal, invitationId, image, createFeedbackReq);
     }
 
     @Operation(summary = "후기 조회", description = "내가 받은/보낸 초대장의 후기를 조회합니다.")
@@ -77,12 +77,12 @@ public class InvitationController {
             @ApiResponse(responseCode = "200", description = "후기 조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class) ) } ),
             @ApiResponse(responseCode = "400", description = "후기 조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @GetMapping(value = "/{receivedInvitationId}/feedback")
+    @GetMapping(value = "/{invitationId}/feedback")
     public ResponseEntity<depth.main.wishwesee.global.payload.ApiResponse> getFeedbacks(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "받은 초대장의 id를 입력해주세요.", required = true) @PathVariable Long receivedInvitationId
+            @Parameter(description = "초대장의 id를 입력해주세요.", required = true) @PathVariable Long invitationId
     ) {
-        return feedbackService.getFeedbacks(userPrincipal, receivedInvitationId);
+        return feedbackService.getFeedbacks(userPrincipal, invitationId);
     }
 
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -22,12 +22,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.net.URI;
 import java.util.Optional;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -1,6 +1,7 @@
 package depth.main.wishwesee.domain.invitation.controller;
 
 import depth.main.wishwesee.domain.invitation.dto.req.CreateFeedbackReq;
+import depth.main.wishwesee.domain.invitation.dto.request.InvitationReq;
 import depth.main.wishwesee.domain.invitation.service.FeedbackService;
 import depth.main.wishwesee.global.config.security.token.CurrentUser;
 import depth.main.wishwesee.global.config.security.token.UserPrincipal;

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -59,8 +59,8 @@ public class InvitationController {
 
     @Operation(summary = "후기 작성", description = "내가 받은/보낸 초대장의 후기를 작성합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "후기 등록 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Void.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "후기 등록 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+            @ApiResponse(responseCode = "200", description = "후기 등록 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Void.class))}),
+            @ApiResponse(responseCode = "400", description = "후기 등록 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
     @PostMapping(value = "/{invitationId}/feedback")
     public ResponseEntity<Void> saveFeedback(
@@ -74,10 +74,10 @@ public class InvitationController {
 
     @Operation(summary = "후기 조회", description = "내가 받은/보낸 초대장의 후기를 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "후기 조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "후기 조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+            @ApiResponse(responseCode = "200", description = "후기 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class))}),
+            @ApiResponse(responseCode = "400", description = "후기 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
-    @GetMapping(value = "/{invitationId}/feedback")
+    @GetMapping("/{invitationId}/feedback")
     public ResponseEntity<depth.main.wishwesee.global.payload.ApiResponse> getFeedbacks(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "초대장의 id를 입력해주세요.", required = true) @PathVariable Long invitationId

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -34,6 +34,8 @@ import java.util.List;
 @RequestMapping("/api/v1/invitation")
 public class InvitationController {
     private final InvitationService invitationService;
+    private final FeedbackService feedbackService;
+
     @Operation(summary = "초대장 작성 완료", description = "임시저장된 초대장 혹은 새로운 초대장 작성을 완료합니다.")
     @PostMapping
     public ResponseEntity<?> createInvitation(
@@ -55,21 +57,32 @@ public class InvitationController {
         return invitationService.saveTemporaryInvitation(invitationReq, cardImage, photoImages, userPrincipal);
     }
 
-    private final FeedbackService feedbackService;
-
     @Operation(summary = "후기 작성", description = "내가 받은/보낸 초대장의 후기를 작성합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "후기 등록 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Void.class) ) } ),
             @ApiResponse(responseCode = "400", description = "후기 등록 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
     @PostMapping(value = "/{receivedInvitationId}/feedback")
-    public ResponseEntity<?> saveFeedback(
+    public ResponseEntity<Void> saveFeedback(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
             @Parameter(description = "받은 초대장의 id를 입력해주세요.", required = true) @PathVariable Long receivedInvitationId,
             @Parameter(description = "후기 이미지입니다. 1장만 입력 가능합니다.") @RequestPart Optional<MultipartFile> image,
             @Parameter(description = "Schemas의 CreateFeedbackReq를 확인해주세요. 후기에 들어갈 내용입니다.") @RequestPart CreateFeedbackReq createFeedbackReq
     ) {
-        feedbackService.saveFeedback(userPrincipal, receivedInvitationId, image, createFeedbackReq);
-        return ResponseEntity.ok().build();
+        return feedbackService.saveFeedback(userPrincipal, receivedInvitationId, image, createFeedbackReq);
     }
+
+    @Operation(summary = "후기 조회", description = "내가 받은/보낸 초대장의 후기를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "후기 조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "후기 조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping(value = "/{receivedInvitationId}/feedback")
+    public ResponseEntity<depth.main.wishwesee.global.payload.ApiResponse> getFeedbacks(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "받은 초대장의 id를 입력해주세요.", required = true) @PathVariable Long receivedInvitationId
+    ) {
+        return feedbackService.getFeedbacks(userPrincipal, receivedInvitationId);
+    }
+
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/Feedback.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/Feedback.java
@@ -1,6 +1,7 @@
 package depth.main.wishwesee.domain.invitation.domain;
 
 import depth.main.wishwesee.domain.common.BaseEntity;
+import depth.main.wishwesee.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,13 +22,18 @@ public class Feedback extends BaseEntity {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "received_invitation_id")
-    private ReceivedInvitation receivedInvitation;
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitation_id")
+    private Invitation invitation;
 
     @Builder
-    public Feedback(String image, String content, ReceivedInvitation receivedInvitation) {
+    public Feedback(String image, String content, User user, Invitation invitation) {
         this.image = image;
         this.content = content;
-        this.receivedInvitation = receivedInvitation;
+        this.user = user;
+        this.invitation = invitation;
     }
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/Feedback.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/Feedback.java
@@ -2,9 +2,12 @@ package depth.main.wishwesee.domain.invitation.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Feedback {
     @Id
@@ -20,4 +23,10 @@ public class Feedback {
     @JoinColumn(name = "invitation_id")
     private Invitation invitation;
 
+    @Builder
+    public Feedback(String image, String content, Invitation invitation) {
+        this.image = image;
+        this.content = content;
+        this.invitation = invitation;
+    }
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/Feedback.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/Feedback.java
@@ -1,5 +1,6 @@
 package depth.main.wishwesee.domain.invitation.domain;
 
+import depth.main.wishwesee.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Feedback {
+public class Feedback extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "feedback_id")
@@ -20,13 +21,13 @@ public class Feedback {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "invitation_id")
-    private Invitation invitation;
+    @JoinColumn(name = "received_invitation_id")
+    private ReceivedInvitation receivedInvitation;
 
     @Builder
-    public Feedback(String image, String content, Invitation invitation) {
+    public Feedback(String image, String content, ReceivedInvitation receivedInvitation) {
         this.image = image;
         this.content = content;
-        this.invitation = invitation;
+        this.receivedInvitation = receivedInvitation;
     }
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/ReceivedInvitation.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/ReceivedInvitation.java
@@ -5,9 +5,11 @@ import depth.main.wishwesee.domain.invitation.domain.Invitation;
 import depth.main.wishwesee.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReceivedInvitation extends BaseEntity{
     @Id

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/FeedbackRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/FeedbackRepository.java
@@ -1,6 +1,7 @@
 package depth.main.wishwesee.domain.invitation.domain.repository;
 
 import depth.main.wishwesee.domain.invitation.domain.Feedback;
+import depth.main.wishwesee.domain.invitation.domain.Invitation;
 import depth.main.wishwesee.domain.invitation.domain.ReceivedInvitation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,7 +9,7 @@ import java.util.List;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
-    List<Feedback> findByReceivedInvitationOrderByCreatedDateDesc(ReceivedInvitation receivedInvitation);
+    List<Feedback> findByInvitationOrderByCreatedDateDesc(Invitation invitation);
 
-    int countByReceivedInvitation(ReceivedInvitation receivedInvitation);
+    int countByInvitation(Invitation invitation);
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/FeedbackRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/FeedbackRepository.java
@@ -1,7 +1,14 @@
 package depth.main.wishwesee.domain.invitation.domain.repository;
 
 import depth.main.wishwesee.domain.invitation.domain.Feedback;
+import depth.main.wishwesee.domain.invitation.domain.ReceivedInvitation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+
+    List<Feedback> findByReceivedInvitationOrderByCreatedDateDesc(ReceivedInvitation receivedInvitation);
+
+    int countByReceivedInvitation(ReceivedInvitation receivedInvitation);
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/ReceivedInvitationRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/ReceivedInvitationRepository.java
@@ -1,7 +1,14 @@
 package depth.main.wishwesee.domain.invitation.domain.repository;
 
+import depth.main.wishwesee.domain.invitation.domain.Invitation;
 import depth.main.wishwesee.domain.invitation.domain.ReceivedInvitation;
+import depth.main.wishwesee.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReceivedInvitationRepository extends JpaRepository<ReceivedInvitation, Long> {
+    Optional<ReceivedInvitation> findByInvitation(Invitation invitation);
+
+    boolean existsByInvitationAndReceiver(Invitation invitation, User user);
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/req/CreateFeedbackReq.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/req/CreateFeedbackReq.java
@@ -1,0 +1,13 @@
+package depth.main.wishwesee.domain.invitation.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import lombok.Getter;
+
+@Getter
+public class CreateFeedbackReq {
+
+    @Max(value = 50, message = "후기는 50자까지 가능합니다.")
+    @Schema(type = "String", example = "너무 재밌는 파티였당", description = "후기의 내용입니다.")
+    private String content;
+}

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/request/CreateFeedbackReq.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/request/CreateFeedbackReq.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 public class CreateFeedbackReq {
 
     @Max(value = 50, message = "후기는 50자까지 가능합니다.")
-    @Schema(type = "String", example = "너무 재밌는 파티였당", description = "후기의 내용입니다. 작성하지 않는 경우 null로 전달합니다.")
+    @Schema(type = "String", example = "너무 재밌는 파티였당", description = "후기의 내용입니다.")
     private String content;
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/request/CreateFeedbackReq.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/request/CreateFeedbackReq.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 public class CreateFeedbackReq {
 
     @Max(value = 50, message = "후기는 50자까지 가능합니다.")
-    @Schema(type = "String", example = "너무 재밌는 파티였당", description = "후기의 내용입니다.")
+    @Schema(type = "String", example = "너무 재밌는 파티였당", description = "후기의 내용입니다. 작성하지 않는 경우 null로 전달합니다.")
     private String content;
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/request/CreateFeedbackReq.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/request/CreateFeedbackReq.java
@@ -1,4 +1,4 @@
-package depth.main.wishwesee.domain.invitation.dto.req;
+package depth.main.wishwesee.domain.invitation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/FeedbackListRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/FeedbackListRes.java
@@ -1,0 +1,17 @@
+package depth.main.wishwesee.domain.invitation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackListRes {
+
+    private int count;
+
+    private List<FeedbackRes> feedbackResList;
+}

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/FeedbackListRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/FeedbackListRes.java
@@ -1,17 +1,22 @@
 package depth.main.wishwesee.domain.invitation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class FeedbackListRes {
 
+    @Schema(type = "int", example = "3", description = "후기의 개수입니다.")
     private int count;
 
+    @Schema(type = "List", example = "Schemas의 FeedbackRes를 확인햊세요.", description = "후기의 리스트입니다.")
     private List<FeedbackRes> feedbackResList;
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/FeedbackRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/FeedbackRes.java
@@ -1,19 +1,25 @@
 package depth.main.wishwesee.domain.invitation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
-
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class FeedbackRes {
 
+    @Schema(type = "Long", example = "1", description = "후기의 id입니다.")
     private Long feedbackId;
 
+    @Schema(type = "String", example = "넘넘 재밌었당", description = "후기의 내용입니다.")
     private String content;
 
+    @Schema(type = "String", example = "https://s3-bucket-name.amazon.com/weohifhbj.png", description = "후기의 사진입니다.")
     private String image;
 
+    @Schema(type = "boolean", example = "true", description = "후기의 삭제 권한 여부입니다. 초대장 수신자는 본인이 작성한 후기만 삭제 가능하며, 발신자는 모두 삭제 가능합니다.")
     private boolean isDeletable;
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/FeedbackRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/FeedbackRes.java
@@ -1,0 +1,19 @@
+package depth.main.wishwesee.domain.invitation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackRes {
+
+    private Long feedbackId;
+
+    private String content;
+
+    private String image;
+
+    private boolean isDeletable;
+}

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
@@ -4,7 +4,7 @@ import depth.main.wishwesee.domain.invitation.domain.Feedback;
 import depth.main.wishwesee.domain.invitation.domain.ReceivedInvitation;
 import depth.main.wishwesee.domain.invitation.domain.repository.FeedbackRepository;
 import depth.main.wishwesee.domain.invitation.domain.repository.ReceivedInvitationRepository;
-import depth.main.wishwesee.domain.invitation.dto.req.CreateFeedbackReq;
+import depth.main.wishwesee.domain.invitation.dto.request.CreateFeedbackReq;
 import depth.main.wishwesee.domain.s3.service.S3Uploader;
 import depth.main.wishwesee.domain.user.domain.User;
 import depth.main.wishwesee.domain.user.domain.repository.UserRepository;
@@ -59,7 +59,10 @@ public class FeedbackService {
 
 
     // 후기 삭제
+
+
     // 후기 조회
+    // 후기 리스트 + 작성자 본인 여부, 총 후기의 개수 전달
 
     private User validateUserById(Long userId) {
         Optional<User> userOptional = userRepository.findById(userId);

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
@@ -2,7 +2,6 @@ package depth.main.wishwesee.domain.invitation.service;
 
 import depth.main.wishwesee.domain.invitation.domain.Feedback;
 import depth.main.wishwesee.domain.invitation.domain.Invitation;
-import depth.main.wishwesee.domain.invitation.domain.ReceivedInvitation;
 import depth.main.wishwesee.domain.invitation.domain.repository.FeedbackRepository;
 import depth.main.wishwesee.domain.invitation.domain.repository.InvitationRepository;
 import depth.main.wishwesee.domain.invitation.domain.repository.ReceivedInvitationRepository;
@@ -24,7 +23,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -59,7 +57,9 @@ public class FeedbackService {
     }
 
     private String uploadImageIfPresent(Optional<MultipartFile> image) {
-        return (image != null && image.isPresent()) ? s3Uploader.uploadFile(image.get()) : null;
+        return image.filter(file -> !file.isEmpty())
+                .map(s3Uploader::uploadFile)
+                .orElse(null);
     }
 
     private String validateContentIfPresent(CreateFeedbackReq createFeedbackReq) {
@@ -109,13 +109,13 @@ public class FeedbackService {
 
     private User validateUserById(Long userId) {
         Optional<User> userOptional = userRepository.findById(userId);
-        DefaultAssert.isOptionalPresent(userOptional);
+        DefaultAssert.isOptionalPresent(userOptional, "사용자가 존재하지 않습니다.");
         return userOptional.get();
     }
 
     private Invitation validateInvitationById(Long invitationId) {
         Optional<Invitation> invitationOptional = invitationRepository.findById(invitationId);
-        DefaultAssert.isOptionalPresent(invitationOptional);
+        DefaultAssert.isOptionalPresent(invitationOptional, "초대장이 존재하지 않습니다.");
         return invitationOptional.get();
     }
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
@@ -80,8 +80,15 @@ public class FeedbackService {
         Invitation invitation = validateInvitationById(invitationId);
         Feedback feedback = validateFeedbackById(feedbackId);
         DefaultAssert.isTrue(invitation.getSender() == user || feedback.getUser() == user, "삭제 권한이 없습니다.");
+        deleteFeedbackImage(feedback.getImage());
         feedbackRepository.delete(feedback);
         return ResponseEntity.noContent().build();
+    }
+
+    private void deleteFeedbackImage(String image) {
+        if (image != null) {
+            s3Uploader.extractImageNameFromUrl(image);
+        }
     }
 
     // 후기 조회

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
@@ -4,6 +4,7 @@ import depth.main.wishwesee.domain.invitation.domain.Feedback;
 import depth.main.wishwesee.domain.invitation.domain.Invitation;
 import depth.main.wishwesee.domain.invitation.domain.ReceivedInvitation;
 import depth.main.wishwesee.domain.invitation.domain.repository.FeedbackRepository;
+import depth.main.wishwesee.domain.invitation.domain.repository.InvitationRepository;
 import depth.main.wishwesee.domain.invitation.domain.repository.ReceivedInvitationRepository;
 import depth.main.wishwesee.domain.invitation.dto.request.CreateFeedbackReq;
 import depth.main.wishwesee.domain.invitation.dto.response.FeedbackListRes;
@@ -32,22 +33,26 @@ public class FeedbackService {
 
     private final UserRepository userRepository;
     private final FeedbackRepository feedbackRepository;
+    private final InvitationRepository invitationRepository;
     private final ReceivedInvitationRepository receivedInvitationRepository;
     private final S3Uploader s3Uploader;
 
 
     // 후기 등록
     @Transactional
-    public ResponseEntity<Void> saveFeedback(UserPrincipal userPrincipal, Long receivedInvitationId, Optional<MultipartFile> image, CreateFeedbackReq createFeedbackReq) {
+    public ResponseEntity<Void> saveFeedback(UserPrincipal userPrincipal, Long invitationId, Optional<MultipartFile> image, CreateFeedbackReq createFeedbackReq) {
         User user = validateUserById(userPrincipal.getId());
-        ReceivedInvitation receivedInvitation = validateReceivedInvitation(receivedInvitationId);
-        DefaultAssert.isTrue(receivedInvitation.getReceiver() == user || receivedInvitation.getInvitation().getSender() == user, "잘못된 접근입니다.");
+        Invitation invitation = validateInvitationById(invitationId);
+        if (invitation.getSender() != user) {
+            DefaultAssert.isTrue(receivedInvitationRepository.existsByInvitationAndReceiver(invitation, user), "내가 받은 초대장이 아닙니다.");
+        }
         String imageUrl = uploadImageIfPresent(image);
         String content = validateContentIfPresent(createFeedbackReq);
         Feedback feedback = Feedback.builder()
                 .image(imageUrl)
                 .content(content)
-                .receivedInvitation(receivedInvitation)
+                .user(user)
+                .invitation(invitation)
                 .build();
         feedbackRepository.save(feedback);
         return ResponseEntity.ok().build();
@@ -70,29 +75,30 @@ public class FeedbackService {
 
 
     // 후기 조회
-    public ResponseEntity<ApiResponse> getFeedbacks(UserPrincipal userPrincipal, Long receivedInvitationId) {
+    public ResponseEntity<ApiResponse> getFeedbacks(UserPrincipal userPrincipal, Long invitationId) {
         User user = validateUserById(userPrincipal.getId());
-        ReceivedInvitation receivedInvitation = validateReceivedInvitation(receivedInvitationId);
-        Invitation invitation = receivedInvitation.getInvitation();
-        DefaultAssert.isTrue(receivedInvitation.getReceiver() == user || invitation.getSender() == user, "잘못된 접근입니다.");
-        boolean isSender = (receivedInvitation.getInvitation().getSender() == user);
-        List<Feedback> feedbacks = feedbackRepository.findByReceivedInvitationOrderByCreatedDateDesc(receivedInvitation);
-
+        Invitation invitation = validateInvitationById(invitationId);
+        boolean isSender;
+        if (invitation.getSender() != user) {
+            isSender = false;
+            DefaultAssert.isTrue(receivedInvitationRepository.existsByInvitationAndReceiver(invitation, user), "내가 받은 초대장이 아닙니다.");
+        } else {
+            isSender = true;
+        }
+        List<Feedback> feedbacks = feedbackRepository.findByInvitationOrderByCreatedDateDesc(invitation);
         List<FeedbackRes> feedbackResList = feedbacks.stream().map(
                 feedback -> FeedbackRes.builder()
                         .feedbackId(feedback.getId())
                         .content(feedback.getContent() != null ? feedback.getContent() : null)
                         .image(feedback.getImage() != null ? feedback.getImage() : null)
-                        .isDeletable(isSender || feedback.getReceivedInvitation().getReceiver() == user)
+                        .isDeletable(isSender || feedback.getUser() == user)
                         .build()
         ).toList();
-
-        int feedbackCount = feedbackRepository.countByReceivedInvitation(receivedInvitation);
+        int feedbackCount = feedbackRepository.countByInvitation(invitation);
         FeedbackListRes feedbackListRes = FeedbackListRes.builder()
                 .count(feedbackCount)
                 .feedbackResList(feedbackResList)
                 .build();
-
         return ResponseEntity.ok(
                 ApiResponse.builder()
                         .check(true)
@@ -107,9 +113,9 @@ public class FeedbackService {
         return userOptional.get();
     }
 
-    private ReceivedInvitation validateReceivedInvitation(Long receivedInvitationId) {
-        Optional<ReceivedInvitation> receivedInvitationOptional = receivedInvitationRepository.findById(receivedInvitationId);
-        DefaultAssert.isOptionalPresent(receivedInvitationOptional);
-        return receivedInvitationOptional.get();
+    private Invitation validateInvitationById(Long invitationId) {
+        Optional<Invitation> invitationOptional = invitationRepository.findById(invitationId);
+        DefaultAssert.isOptionalPresent(invitationOptional);
+        return invitationOptional.get();
     }
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
@@ -87,7 +87,8 @@ public class FeedbackService {
 
     private void deleteFeedbackImage(String image) {
         if (image != null) {
-            s3Uploader.extractImageNameFromUrl(image);
+            String imageName = s3Uploader.extractImageNameFromUrl(image);
+            s3Uploader.deleteFile(imageName);
         }
     }
 

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
@@ -1,0 +1,75 @@
+package depth.main.wishwesee.domain.invitation.service;
+
+import depth.main.wishwesee.domain.invitation.domain.Feedback;
+import depth.main.wishwesee.domain.invitation.domain.ReceivedInvitation;
+import depth.main.wishwesee.domain.invitation.domain.repository.FeedbackRepository;
+import depth.main.wishwesee.domain.invitation.domain.repository.ReceivedInvitationRepository;
+import depth.main.wishwesee.domain.invitation.dto.req.CreateFeedbackReq;
+import depth.main.wishwesee.domain.s3.service.S3Uploader;
+import depth.main.wishwesee.domain.user.domain.User;
+import depth.main.wishwesee.domain.user.domain.repository.UserRepository;
+import depth.main.wishwesee.global.DefaultAssert;
+import depth.main.wishwesee.global.config.security.token.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.security.InvalidParameterException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FeedbackService {
+
+    private final UserRepository userRepository;
+    private final FeedbackRepository feedbackRepository;
+    private final ReceivedInvitationRepository receivedInvitationRepository;
+    private final S3Uploader s3Uploader;
+
+
+    // 후기 등록
+    @Transactional
+    public void saveFeedback(UserPrincipal userPrincipal, Long receivedInvitationId, Optional<MultipartFile> image, CreateFeedbackReq createFeedbackReq) {
+        User user = validateUserById(userPrincipal.getId());
+        ReceivedInvitation receivedInvitation = validateReceivedInvitation(receivedInvitationId);
+        DefaultAssert.isTrue(receivedInvitation.getReceiver() == user, "내가 받은 초대장이 아닙니다.");
+        String imageUrl = uploadImageIfPresent(image);
+        String content = validateContentIfPresent(createFeedbackReq);
+        Feedback feedback = Feedback.builder()
+                .image(imageUrl)
+                .content(content)
+                .invitation(receivedInvitation.getInvitation())
+                .build();
+        feedbackRepository.save(feedback);
+    }
+
+    private String uploadImageIfPresent(Optional<MultipartFile> image) {
+        return (image != null && image.isPresent()) ? s3Uploader.uploadFile(image.get()) : null;
+    }
+
+    private String validateContentIfPresent(CreateFeedbackReq createFeedbackReq) {
+        String content = (createFeedbackReq.getContent() != null && !createFeedbackReq.getContent().isEmpty()) ? createFeedbackReq.getContent() : null;
+        if (content != null && content.length() > 50) {
+            throw new InvalidParameterException("후기는 50자까지 작성 가능합니다.");
+        }
+        return content;
+    }
+
+
+    // 후기 삭제
+    // 후기 조회
+
+    private User validateUserById(Long userId) {
+        Optional<User> userOptional = userRepository.findById(userId);
+        DefaultAssert.isOptionalPresent(userOptional);
+        return userOptional.get();
+    }
+
+    private ReceivedInvitation validateReceivedInvitation(Long receivedInvitationId) {
+        Optional<ReceivedInvitation> receivedInvitationOptional = receivedInvitationRepository.findById(receivedInvitationId);
+        DefaultAssert.isOptionalPresent(receivedInvitationOptional);
+        return receivedInvitationOptional.get();
+    }
+}

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
@@ -38,7 +38,7 @@ public class FeedbackService {
 
     // 후기 등록
     @Transactional
-    public ResponseEntity<Void> saveFeedback(UserPrincipal userPrincipal, Long invitationId, Optional<MultipartFile> image, CreateFeedbackReq createFeedbackReq) {
+    public ResponseEntity<Void> saveFeedback(UserPrincipal userPrincipal, Long invitationId, MultipartFile image, CreateFeedbackReq createFeedbackReq) {
         User user = validateUserById(userPrincipal.getId());
         Invitation invitation = validateInvitationById(invitationId);
         if (invitation.getSender() != user) {
@@ -56,14 +56,17 @@ public class FeedbackService {
         return ResponseEntity.ok().build();
     }
 
-    private String uploadImageIfPresent(Optional<MultipartFile> image) {
-        return image.filter(file -> !file.isEmpty())
-                .map(s3Uploader::uploadFile)
-                .orElse(null);
+    private String uploadImageIfPresent(MultipartFile image) {
+        return image != null && !image.isEmpty() ? s3Uploader.uploadFile(image) : null;
     }
 
     private String validateContentIfPresent(CreateFeedbackReq createFeedbackReq) {
-        String content = (createFeedbackReq.getContent() != null && !createFeedbackReq.getContent().isEmpty()) ? createFeedbackReq.getContent() : null;
+        if (createFeedbackReq == null) {
+            return null;
+        }
+        String content = (createFeedbackReq.getContent() != null && !createFeedbackReq.getContent().isEmpty())
+                ? createFeedbackReq.getContent()
+                : null;
         if (content != null && content.length() > 50) {
             throw new InvalidParameterException("후기는 50자까지 작성 가능합니다.");
         }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
@@ -1,6 +1,7 @@
 package depth.main.wishwesee.domain.invitation.service;
 
 import depth.main.wishwesee.domain.invitation.domain.Feedback;
+import depth.main.wishwesee.domain.invitation.domain.Invitation;
 import depth.main.wishwesee.domain.invitation.domain.ReceivedInvitation;
 import depth.main.wishwesee.domain.invitation.domain.repository.FeedbackRepository;
 import depth.main.wishwesee.domain.invitation.domain.repository.ReceivedInvitationRepository;
@@ -10,12 +11,14 @@ import depth.main.wishwesee.domain.user.domain.User;
 import depth.main.wishwesee.domain.user.domain.repository.UserRepository;
 import depth.main.wishwesee.global.DefaultAssert;
 import depth.main.wishwesee.global.config.security.token.UserPrincipal;
+import depth.main.wishwesee.global.payload.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.security.InvalidParameterException;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -34,13 +37,13 @@ public class FeedbackService {
     public void saveFeedback(UserPrincipal userPrincipal, Long receivedInvitationId, Optional<MultipartFile> image, CreateFeedbackReq createFeedbackReq) {
         User user = validateUserById(userPrincipal.getId());
         ReceivedInvitation receivedInvitation = validateReceivedInvitation(receivedInvitationId);
-        DefaultAssert.isTrue(receivedInvitation.getReceiver() == user, "내가 받은 초대장이 아닙니다.");
+        DefaultAssert.isTrue(receivedInvitation.getReceiver() == user || receivedInvitation.getInvitation().getSender() == user, "잘못된 접근입니다.");
         String imageUrl = uploadImageIfPresent(image);
         String content = validateContentIfPresent(createFeedbackReq);
         Feedback feedback = Feedback.builder()
                 .image(imageUrl)
                 .content(content)
-                .invitation(receivedInvitation.getInvitation())
+                .receivedInvitation(receivedInvitation)
                 .build();
         feedbackRepository.save(feedback);
     }
@@ -62,7 +65,7 @@ public class FeedbackService {
 
 
     // 후기 조회
-    // 후기 리스트 + 작성자 본인 여부, 총 후기의 개수 전달
+
 
     private User validateUserById(Long userId) {
         Optional<User> userOptional = userRepository.findById(userId);

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
@@ -70,9 +70,16 @@ public class FeedbackService {
         return content;
     }
 
-
     // 후기 삭제
-
+    @Transactional
+    public ResponseEntity<Void> deleteFeedback(UserPrincipal userPrincipal, Long invitationId, Long feedbackId) {
+        User user = validateUserById(userPrincipal.getId());
+        Invitation invitation = validateInvitationById(invitationId);
+        Feedback feedback = validateFeedbackById(feedbackId);
+        DefaultAssert.isTrue(invitation.getSender() == user || feedback.getUser() == user, "삭제 권한이 없습니다.");
+        feedbackRepository.delete(feedback);
+        return ResponseEntity.noContent().build();
+    }
 
     // 후기 조회
     public ResponseEntity<ApiResponse> getFeedbacks(UserPrincipal userPrincipal, Long invitationId) {
@@ -117,5 +124,11 @@ public class FeedbackService {
         Optional<Invitation> invitationOptional = invitationRepository.findById(invitationId);
         DefaultAssert.isOptionalPresent(invitationOptional, "초대장이 존재하지 않습니다.");
         return invitationOptional.get();
+    }
+
+    private Feedback validateFeedbackById(Long feedbackId) {
+        Optional<Feedback> feedbackOptional = feedbackRepository.findById(feedbackId);
+        DefaultAssert.isOptionalPresent(feedbackOptional, "후기가 존재하지 않습니다.");
+        return feedbackOptional.get();
     }
 }

--- a/src/main/java/depth/main/wishwesee/domain/s3/service/S3Uploader.java
+++ b/src/main/java/depth/main/wishwesee/domain/s3/service/S3Uploader.java
@@ -71,4 +71,8 @@ public class S3Uploader {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다.", e);
         }
     }
+
+    public String extractImageNameFromUrl(String imageUrl) {
+        return imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
+    }
 }

--- a/src/main/java/depth/main/wishwesee/domain/user/controller/UserController.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/controller/UserController.java
@@ -1,6 +1,5 @@
 package depth.main.wishwesee.domain.user.controller;
 
-import depth.main.wishwesee.domain.invitation.dto.req.CreateFeedbackReq;
 import depth.main.wishwesee.domain.user.service.UserService;
 import depth.main.wishwesee.global.config.security.token.CurrentUser;
 import depth.main.wishwesee.global.config.security.token.UserPrincipal;
@@ -14,9 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/depth/main/wishwesee/domain/user/controller/UserController.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/controller/UserController.java
@@ -1,11 +1,39 @@
 package depth.main.wishwesee.domain.user.controller;
 
+import depth.main.wishwesee.domain.invitation.dto.req.CreateFeedbackReq;
+import depth.main.wishwesee.domain.user.service.UserService;
+import depth.main.wishwesee.global.config.security.token.CurrentUser;
+import depth.main.wishwesee.global.config.security.token.UserPrincipal;
+import depth.main.wishwesee.global.payload.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/user")
 public class UserController {
+
+    private final UserService userService;
+    @Operation(summary = "구글 계정명/프로필 사진 조회", description = "로그인한 사용자의 구글 계정명, 프로필 사진 url을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = depth.main.wishwesee.global.payload.ApiResponse.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @GetMapping(value = "")
+    public ResponseEntity<depth.main.wishwesee.global.payload.ApiResponse> saveFeedback(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return ResponseEntity.ok(userService.getProfile(userPrincipal));
+    }
+
 }

--- a/src/main/java/depth/main/wishwesee/domain/user/dto/res/UserProfileRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/dto/res/UserProfileRes.java
@@ -1,0 +1,21 @@
+package depth.main.wishwesee.domain.user.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileRes {
+
+    @Schema(type = "Long", example = "1", description = "사용자의 userId입니다.")
+    private Long userId;
+
+    @Schema(type = "String", example = "김뎁스", description = "사용자의 이름입니다.")
+    private String name;
+
+    @Schema(type = "String", example = "https://lh3.googleusercontent.com/a/ACg8ocLU6k_7elIaIDZKUmqVPU3bg-Eajwu-gV", description = "사용자의 프로필 사진입니다.")
+    private String image;
+}

--- a/src/main/java/depth/main/wishwesee/domain/user/dto/response/UserProfileRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/dto/response/UserProfileRes.java
@@ -1,4 +1,4 @@
-package depth.main.wishwesee.domain.user.dto.res;
+package depth.main.wishwesee.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/depth/main/wishwesee/domain/user/dto/response/UserProfileRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/dto/response/UserProfileRes.java
@@ -3,8 +3,10 @@ package depth.main.wishwesee.domain.user.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/depth/main/wishwesee/domain/user/service/UserService.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/service/UserService.java
@@ -34,7 +34,7 @@ public class UserService {
 
     private User validateUserById(Long userId) {
         Optional<User> userOptional = userRepository.findById(userId);
-        DefaultAssert.isOptionalPresent(userOptional);
+        DefaultAssert.isOptionalPresent(userOptional, "사용자가 존재하지 않습니다.");
         return userOptional.get();
     }
 }

--- a/src/main/java/depth/main/wishwesee/domain/user/service/UserService.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/service/UserService.java
@@ -2,7 +2,7 @@ package depth.main.wishwesee.domain.user.service;
 
 import depth.main.wishwesee.domain.user.domain.User;
 import depth.main.wishwesee.domain.user.domain.repository.UserRepository;
-import depth.main.wishwesee.domain.user.dto.res.UserProfileRes;
+import depth.main.wishwesee.domain.user.dto.response.UserProfileRes;
 import depth.main.wishwesee.global.DefaultAssert;
 import depth.main.wishwesee.global.config.security.token.UserPrincipal;
 import depth.main.wishwesee.global.payload.ApiResponse;

--- a/src/main/java/depth/main/wishwesee/domain/user/service/UserService.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/service/UserService.java
@@ -1,11 +1,40 @@
 package depth.main.wishwesee.domain.user.service;
 
+import depth.main.wishwesee.domain.user.domain.User;
+import depth.main.wishwesee.domain.user.domain.repository.UserRepository;
+import depth.main.wishwesee.domain.user.dto.res.UserProfileRes;
+import depth.main.wishwesee.global.DefaultAssert;
+import depth.main.wishwesee.global.config.security.token.UserPrincipal;
+import depth.main.wishwesee.global.payload.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
+
+    private final UserRepository userRepository;
+
+    public ApiResponse getProfile(UserPrincipal userPrincipal) {
+        User user = validateUserById(userPrincipal.getId());
+        UserProfileRes userProfileRes = UserProfileRes.builder()
+                .userId(user.getId())
+                .name(user.getName())
+                .image(user.getProfile())
+                .build();
+        return ApiResponse.builder()
+                .check(true)
+                .information(userProfileRes)
+                .build();
+    }
+
+    private User validateUserById(Long userId) {
+        Optional<User> userOptional = userRepository.findById(userId);
+        DefaultAssert.isOptionalPresent(userOptional);
+        return userOptional.get();
+    }
 }

--- a/src/main/java/depth/main/wishwesee/global/DefaultAssert.java
+++ b/src/main/java/depth/main/wishwesee/global/DefaultAssert.java
@@ -35,9 +35,9 @@ public class DefaultAssert extends Assert {
         }
     }
 
-    public static void isOptionalPresent(Optional<?> value){
+    public static void isOptionalPresent(Optional<?> value, String message){
         if(!value.isPresent()){
-            throw new DefaultException(ErrorCode.INVALID_PARAMETER);
+            throw new DefaultException(ErrorCode.INVALID_PARAMETER, message);
         }
     }
 

--- a/src/main/java/depth/main/wishwesee/global/config/security/SecurityConfig.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -67,7 +68,7 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(List.of(
                 "http://localhost:3000"));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
 
@@ -87,11 +88,17 @@ public class SecurityConfig {
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(new CustomAuthenticationEntryPoint()))
                 .authorizeHttpRequests(
                         authorize -> authorize
-                                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                                .requestMatchers("/auth/**").permitAll()
-                                .requestMatchers("/api/v1/invitation").permitAll()
+                                .requestMatchers("/auth/**", "/oauth2/**")
+                                .permitAll()
+                                .requestMatchers("/error", "/favicon.ico", "/**.png", "/**.gif", "/**.svg", "/**.jpg", "/**.html", "/**.css", "/**.js")
+                                .permitAll()
+                                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**")
+                                .permitAll()
+                                .requestMatchers("/api/v1/invitation")
+                                .permitAll()
                                 .anyRequest().authenticated()
                 )
+                .addFilterBefore(customOncePerRequestFilter(), UsernamePasswordAuthenticationFilter.class)
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authorization -> authorization
                                 .baseUri("/oauth2/authorize")

--- a/src/main/java/depth/main/wishwesee/global/config/security/handler/CustomSimpleUrlAuthenticationSuccessHandler.java
+++ b/src/main/java/depth/main/wishwesee/global/config/security/handler/CustomSimpleUrlAuthenticationSuccessHandler.java
@@ -3,7 +3,7 @@ package depth.main.wishwesee.global.config.security.handler;
 import depth.main.wishwesee.domain.auth.domain.Token;
 import depth.main.wishwesee.domain.auth.domain.repository.CustomAuthorizationRequestRepository;
 import depth.main.wishwesee.domain.auth.domain.repository.TokenRepository;
-import depth.main.wishwesee.domain.auth.dto.res.TokenMapping;
+import depth.main.wishwesee.domain.auth.dto.response.TokenMapping;
 import depth.main.wishwesee.domain.auth.service.CustomTokenProviderService;
 import depth.main.wishwesee.global.DefaultAssert;
 import depth.main.wishwesee.global.config.security.OAuth2Config;


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- 내가 보낸/받은 초대장의 후기 작성, 조회, 삭제하는 API를 구현했습니다.


## 💬리뷰 요구사항(선택)
> 리뷰어가 신경써서 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
### 1. 구글 로그인 시 발생하는 `401 Unauthorized` 오류 수정
구글 콘솔 프로젝트 설정 및 securityConfig에 오류가 있었던 것으로 보입니다. 수정했습니다!
### 2. dto 디렉토리명 통일
req/request 로 통일되어 있지 않아서 request, response로 통일했습니다
### 3. Feedback 테이블 컬럼 추가
```
@ManyToOne(fetch = FetchType.LAZY)
@JoinColumn(name = "user_id")
private User user;
```
- 기획 문의 결과, 후기 삭제를 위해 작성자 구분이 필요하여 추가했습니다.
### 4. 후기 관련 기획 변동 사항
- 본인이 작성한 후기만 삭제 가능하고 초대장 작성자는 본인 초대장의 모든 후기 삭제 가능


## ✅Check
- [x] 각 기능에 대한 테스트
- [x] label
- [x] develop branch pull



## #️⃣연관된 이슈
> ex) #이슈번호
- resolve #5 


## 💡References(선택)
> 작업하면서 참고한 레퍼런스가 있다면 첨부해주세요
- 
