### PR TITLE
[FEAT] 내가 받은/보낸 초대장 기능 구현

### DIFF
--- a/src/main/java/depth/main/wishwesee/domain/content/domain/Block.java
+++ b/src/main/java/depth/main/wishwesee/domain/content/domain/Block.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,6 +22,7 @@ public class Block {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "invitation_id")
+    //@OnDelete(action = OnDeleteAction.CASCADE)
     private Invitation invitation;
 
     protected Block(int sequence, Invitation invitation) {

--- a/src/main/java/depth/main/wishwesee/domain/content/domain/repository/BlockRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/content/domain/repository/BlockRepository.java
@@ -18,4 +18,6 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 
     @Query("SELECT b FROM Block b WHERE b.invitation.id = :invitationId")
     List<Block> findByInvitationId(@Param("invitationId") Long invitationId);
+
+    void deleteByInvitation(Invitation invitation);
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -175,5 +175,32 @@ public class InvitationController {
     ) {
         return invitationService.getReceivedInvitationsByYear(userPrincipal, year);
     }
+    @Operation(summary = "보낸 초대장 삭제", description = "사용자가 보낸 초대장을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "성공적으로 삭제됨"),
+            @ApiResponse(responseCode = "404", description = "초대장 또는 사용자를 찾을 수 없음"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터 (삭제 권한 없음)")
+    })
+    @DeleteMapping("/sent/{invitationId}")
+    public ResponseEntity<?> deleteSentInvitation(
+            @Parameter(description = "삭제할 초대장의 ID", required = true) @PathVariable Long invitationId,
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal) {
+
+        return invitationService.deleteSentInvitation(invitationId, userPrincipal);
+    }
+
+    @Operation(summary = "받은 초대장 삭제", description = "사용자가 받은 초대장을 삭제합니다. 삭제 시 초대장 자체는 삭제되지 않고 사용자의 수신 목록에서만 삭제됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "성공적으로 삭제됨"),
+            @ApiResponse(responseCode = "404", description = "해당 초대장이 존재하지 않거나 수신하지 않음")
+    })
+    @DeleteMapping("/received/{invitationId}")
+    public ResponseEntity<?> deleteReceivedInvitation(
+            @Parameter(description = "삭제할 초대장의 ID", required = true)  @PathVariable Long invitationId,
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal) {
+
+        return invitationService.deleteReceivedInvitation(invitationId, userPrincipal);
+    }
+
 
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/Feedback.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/Feedback.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -27,6 +29,7 @@ public class Feedback extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "invitation_id")
+    //@OnDelete(action = OnDeleteAction.CASCADE)
     private Invitation invitation;
 
     @Builder

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/ReceivedInvitation.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/ReceivedInvitation.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -23,6 +25,7 @@ public class ReceivedInvitation extends BaseEntity{
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "invitation_id")
+    //@OnDelete(action = OnDeleteAction.CASCADE)
     private Invitation invitation;
 
     @Builder

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/FeedbackRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/FeedbackRepository.java
@@ -12,4 +12,6 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     List<Feedback> findByInvitationOrderByCreatedDateDesc(Invitation invitation);
 
     int countByInvitation(Invitation invitation);
+
+    void deleteByInvitation(Invitation invitation);
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/ReceivedInvitationRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/ReceivedInvitationRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 public interface ReceivedInvitationRepository extends JpaRepository<ReceivedInvitation, Long> {
     Optional<ReceivedInvitation> findByInvitation(Invitation invitation);
-
+    Optional<ReceivedInvitation> findByReceiverAndInvitationId(User receiver, Long invitationId);
     boolean existsByInvitationAndReceiver(Invitation invitation, User user);
     boolean existsByReceiverAndInvitation(User receiver, Invitation invitation);
 
@@ -22,4 +22,6 @@ public interface ReceivedInvitationRepository extends JpaRepository<ReceivedInvi
     @Query("SELECT ri FROM ReceivedInvitation ri WHERE ri.receiver = :user AND YEAR(ri.createdDate) = :year ORDER BY ri.createdDate DESC")
     List<ReceivedInvitation> findByReceiverAndYear(@Param("user") User user, @Param("year") int year); // 연도별 받은 초대장
 
+
+    void deleteByInvitation(Invitation invitation);
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/CompletedInvitationRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/CompletedInvitationRes.java
@@ -16,6 +16,9 @@ public class CompletedInvitationRes {
     @Schema(description = "초대장ID", example = "1", type = "Long")
     private Long invitationId;
 
+    @Schema(description = "작성자 본인 여부", example = "true", type = "boolean")
+    private boolean isOwner;
+
     @Schema(description = "카드 이미지 URL", example = "https://wishwesee-s3-image-bucket.s3.amazonaws.com/3f78b60d-c3b5-46db-aab2-9f8245ad7b35.jpg", type = "String")
     private String cardImage;
 
@@ -67,10 +70,10 @@ public class CompletedInvitationRes {
     private List<BlockRes> blocks; // 블록 리스트
 
     @Builder
-    public CompletedInvitationRes(Long invitationId, String title, String cardImage, LocalDate startDate,
-                                  LocalTime startTime, LocalDate endDate, LocalTime endTime, String location, String address,
-                                  String mapLink, int mapViewType, LocalDate voteDeadline, boolean scheduleVoteMultiple, boolean scheduleVoteClosed,
-                                  List<BlockRes> blocks, List<ScheduleVoteRes> scheduleVotes) {
+    public CompletedInvitationRes(Long invitationId, boolean isOwner, String cardImage, String title, LocalDate startDate,
+                                  LocalTime startTime, LocalDate endDate, LocalTime endTime, LocalDate voteDeadline, boolean scheduleVoteMultiple,
+                                  List<ScheduleVoteRes> scheduleVotes, boolean scheduleVoteClosed, int mapViewType, String location, String address,
+                                  String mapLink, List<BlockRes> blocks) {
 
         this.invitationId = invitationId;
         this.title = title;
@@ -88,6 +91,7 @@ public class CompletedInvitationRes {
         this.scheduleVoteClosed = scheduleVoteClosed;
         this.blocks = blocks;
         this.scheduleVotes = scheduleVotes;
+        this.isOwner = isOwner;
     }
 
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/InvitationService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/InvitationService.java
@@ -291,6 +291,9 @@ public class InvitationService {
         Invitation invitation = invitationRepository.findById(invitationId)
                 .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "해당 초대장이 존재하지 않습니다."));
 
+        // 작성자 본인 여부 확인
+        boolean isOwner = invitation.getSender().getId().equals(userPrincipal.getId());
+
         // 초대장의 모든 블록 조회
         List<Block> allBlocks = blockRepository.findByInvitationId(invitation.getId());
 
@@ -338,6 +341,7 @@ public class InvitationService {
         // 응답 DTO 생성
         CompletedInvitationRes response = CompletedInvitationRes.builder()
                 .invitationId(invitation.getId())
+                .isOwner(isOwner)
                 .cardImage(invitation.getCardImage())
                 .title(invitation.getTitle())
                 .startDate(invitation.getStartDate())

--- a/src/main/java/depth/main/wishwesee/domain/vote/domain/Attendance.java
+++ b/src/main/java/depth/main/wishwesee/domain/vote/domain/Attendance.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 
 @Getter
@@ -29,6 +31,7 @@ public class Attendance {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "invitation_id")
+    //@OnDelete(action = OnDeleteAction.CASCADE)
     private Invitation invitation;
 
     @Builder

--- a/src/main/java/depth/main/wishwesee/domain/vote/domain/ScheduleVote.java
+++ b/src/main/java/depth/main/wishwesee/domain/vote/domain/ScheduleVote.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -29,6 +31,7 @@ public class ScheduleVote {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "invitation_id")
+    //@OnDelete(action = OnDeleteAction.CASCADE)
     private Invitation invitation;
 
     @Builder

--- a/src/main/java/depth/main/wishwesee/domain/vote/domain/VoterNickname.java
+++ b/src/main/java/depth/main/wishwesee/domain/vote/domain/VoterNickname.java
@@ -5,6 +5,8 @@ import depth.main.wishwesee.domain.vote.domain.ScheduleVote;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,6 +24,7 @@ public class VoterNickname {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule_vote_id")
+    //@OnDelete(action = OnDeleteAction.CASCADE)
     private ScheduleVote scheduleVote;
 
 }

--- a/src/main/java/depth/main/wishwesee/domain/vote/domain/repository/AttendanceRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/vote/domain/repository/AttendanceRepository.java
@@ -23,4 +23,5 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
 
     boolean existsByInvitationAndNicknameAndUser(Invitation invitation, String nickname, User user);
 
+    void deleteByInvitation(Invitation invitation);
 }

--- a/src/main/java/depth/main/wishwesee/domain/vote/domain/repository/VoteRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/vote/domain/repository/VoteRepository.java
@@ -13,4 +13,8 @@ public interface VoteRepository extends JpaRepository<ScheduleVote, Long> {
 
     @Query("SELECT v FROM ScheduleVote v WHERE v.invitation.id = :invitationId")
     List<ScheduleVote> findByInvitationId(@Param("invitationId") Long invitationId);
+
+    List<ScheduleVote> findByInvitation(Invitation invitation);
+
+    void deleteByInvitation(Invitation invitation);
 }

--- a/src/main/java/depth/main/wishwesee/domain/vote/domain/repository/VoterNicknameRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/vote/domain/repository/VoterNicknameRepository.java
@@ -1,7 +1,9 @@
 package depth.main.wishwesee.domain.vote.domain.repository;
 
+import depth.main.wishwesee.domain.vote.domain.ScheduleVote;
 import depth.main.wishwesee.domain.vote.domain.VoterNickname;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VoterNicknameRepository extends JpaRepository<VoterNickname, Long> {
+    void deleteByScheduleVote(ScheduleVote scheduleVote);
 }


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
### 1. 내가 보낸 초대장 삭제
초대장 데이터와 연관된 데이터(Block, Feedback, ReceivedInvitation, Attendance, ScheduleVote, VoterNickname) 를 데이터베이스에서 완전히 삭제 (받은 사람들의 목록에서도 제거됨)
### 2. 내가 받은 초대장 삭제
초대장 데이터(Invitation)는 유지 ->  현재 사용자와 초대장의 연관 관계(ReceivedInvitation)만 삭제 (보낸 사람의 목록에는 영향	을 미치지 않음)

**+완성된 초대장 조회 시 작성자 본인 여부를 응답에 추가하였습니다!**

## 💬리뷰 요구사항(선택)
> 리뷰어가 신경써서 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- ### 초대장 삭제 시 연관된 데이터를 삭제하기 위해 자동으로 연관 데이터를 처리하는 JPA의 Cascade 및 _@OnDelete(action = OnDeleteAction.CASCADE)_를 사용하는 방식을 고려했으나, 이미 생성된 데이터베이스에 적용하려면, 외래 키에 ON DELETE CASCADE를 수동으로 설정해야 해서 자식 엔티티를 수동으로 하나씩 삭제하는 방식으로 구현했습니다! 


## ✅Check
- [x] 각 기능에 대한 테스트
- [x] label
- [x] develop branch pull



## #️⃣연관된 이슈
> ex) #이슈번호
- resolve #20


## 💡References(선택)
> 작업하면서 참고한 레퍼런스가 있다면 첨부해주세요
- 
