### PR TITLE
[FEAT] 회원 탈퇴 및 후기 알림 API 구현

### DIFF
--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -2,11 +2,8 @@ package depth.main.wishwesee.domain.invitation.controller;
 
 import depth.main.wishwesee.domain.invitation.dto.request.CreateFeedbackReq;
 import depth.main.wishwesee.domain.invitation.dto.request.InvitationReq;
-import depth.main.wishwesee.domain.invitation.dto.response.FeedbackListRes;
+import depth.main.wishwesee.domain.invitation.dto.response.*;
 import depth.main.wishwesee.domain.invitation.dto.request.SaveInvitationReq;
-import depth.main.wishwesee.domain.invitation.dto.response.CompletedInvitationRes;
-import depth.main.wishwesee.domain.invitation.dto.response.InvitationListRes;
-import depth.main.wishwesee.domain.invitation.dto.response.MyInvitationOverViewRes;
 import depth.main.wishwesee.domain.invitation.service.FeedbackService;
 import depth.main.wishwesee.global.config.security.token.CurrentUser;
 import depth.main.wishwesee.global.config.security.token.UserPrincipal;
@@ -87,6 +84,18 @@ public class InvitationController {
             @Parameter(description = "초대장의 id를 입력해주세요.", required = true) @PathVariable Long invitationId
     ) {
         return feedbackService.getFeedbacks(userPrincipal, invitationId);
+    }
+
+    @Operation(summary = "후기 알림이 가능한 초대장 목록 조회", description = "내가 받은 초대장 중 후기 알림이 가능한 초대장 목록을 조회합니다. 이미 후기를 작성한 경우 보내지 않습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "목록 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = NotificationFeedbackRes.class))}),
+            @ApiResponse(responseCode = "400", description = "목록 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @GetMapping("/my-invitations/feedback")
+    public ResponseEntity<depth.main.wishwesee.global.payload.ApiResponse> getWritableFeedbackNotification(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return feedbackService.notificationWritableFeedback(userPrincipal);
     }
 
     @Operation(summary = "후기 삭제", description = "내가 받은/보낸 초대장의 후기를 삭제합니다.")

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/FeedbackRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/FeedbackRepository.java
@@ -2,7 +2,7 @@ package depth.main.wishwesee.domain.invitation.domain.repository;
 
 import depth.main.wishwesee.domain.invitation.domain.Feedback;
 import depth.main.wishwesee.domain.invitation.domain.Invitation;
-import depth.main.wishwesee.domain.invitation.domain.ReceivedInvitation;
+import depth.main.wishwesee.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -16,4 +16,6 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     int countByInvitation(Invitation invitation);
 
     void deleteByInvitation(Invitation invitation);
+
+    boolean existsByInvitationAndUser(Invitation invitation, User user);
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/ReceivedInvitationRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/ReceivedInvitationRepository.java
@@ -2,13 +2,13 @@ package depth.main.wishwesee.domain.invitation.domain.repository;
 
 import depth.main.wishwesee.domain.invitation.domain.Invitation;
 import depth.main.wishwesee.domain.invitation.domain.ReceivedInvitation;
-import depth.main.wishwesee.domain.invitation.dto.response.MyInvitationOverViewRes;
 import depth.main.wishwesee.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,4 +25,9 @@ public interface ReceivedInvitationRepository extends JpaRepository<ReceivedInvi
 
 
     void deleteByInvitation(Invitation invitation);
+
+    List<ReceivedInvitation> findByReceiverAndCreatedDateAfter(User user, LocalDateTime dateTime);
+
+
+
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/FeedbackListRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/FeedbackListRes.java
@@ -1,5 +1,7 @@
 package depth.main.wishwesee.domain.invitation.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +19,10 @@ public class FeedbackListRes {
 
     @Schema(type = "int", example = "3", description = "후기의 개수입니다.")
     private int count;
+
+    @Schema(type = "boolean", example = "true", description = "후기 작성이 가능한 상태인지 여부")
+    @JsonProperty("isWritable")
+    private boolean writable;
 
     @Schema(type = "List", example = "Schemas의 FeedbackRes를 확인해주세요.", description = "후기의 리스트입니다.")
     private List<FeedbackRes> feedbackResList;

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/NotificationFeedbackRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/NotificationFeedbackRes.java
@@ -1,0 +1,21 @@
+package depth.main.wishwesee.domain.invitation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "NotificationFeedbackRes: 후기 알림이 가능한 초대장 목록 조회 응답 객체", description = "GET: /api/v1/invitation/my-invitations/feedback에서 사용합니다.")
+public class NotificationFeedbackRes {
+
+    @Schema(description = "초대장ID", example = "1", type = "Long")
+    private Long invitationId;
+
+    @Schema(description = "초대장 제목", example = "크리스마스", type = "String")
+    private String title;
+}

--- a/src/main/java/depth/main/wishwesee/domain/user/controller/UserController.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package depth.main.wishwesee.domain.user.controller;
 
+import depth.main.wishwesee.domain.user.dto.response.UserProfileRes;
 import depth.main.wishwesee.domain.user.service.UserService;
 import depth.main.wishwesee.global.config.security.token.CurrentUser;
 import depth.main.wishwesee.global.config.security.token.UserPrincipal;
@@ -24,7 +25,7 @@ public class UserController {
     private final UserService userService;
     @Operation(summary = "구글 계정명/프로필 사진 조회", description = "로그인한 사용자의 구글 계정명, 프로필 사진 url을 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = depth.main.wishwesee.global.payload.ApiResponse.class) ) } ),
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UserProfileRes.class) ) } ),
             @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
     @GetMapping(value = "")
@@ -32,6 +33,19 @@ public class UserController {
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
     ) {
         return ResponseEntity.ok(userService.getProfile(userPrincipal));
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다. 이 경우, 닉네임, 초대장, 후기, 투표 전적을 제외한 회원의 개인정보만 삭제됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Void.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @DeleteMapping(value = "")
+    public ResponseEntity<Void> deleteUser(
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
+    ) {
+        userService.encryptUserInfoOnDelete(userPrincipal);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/depth/main/wishwesee/domain/user/domain/User.java
+++ b/src/main/java/depth/main/wishwesee/domain/user/domain/User.java
@@ -31,5 +31,11 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    public void updateUserInfo(String email, String password, String profile, String providerId) {
+        this.email = email;
+        this.password = password;
+        this.profile = profile;
+        this.providerId = providerId;
+    }
 }
 

--- a/src/main/java/depth/main/wishwesee/domain/vote/service/ScheduleVoteService.java
+++ b/src/main/java/depth/main/wishwesee/domain/vote/service/ScheduleVoteService.java
@@ -138,8 +138,16 @@ public class ScheduleVoteService {
         checkVoteClosed(invitation);
         ScheduleVote scheduleVote = validateScheduleVoteById(scheduleVoteId);
         invitation.updateSchedule(scheduleVote.getStartDate(), scheduleVote.getStartTime(), scheduleVote.getEndDate(), scheduleVote.getEndTime());
+        deleteScheduleVoteAndVoters(invitation);
         return ResponseEntity.noContent().build();
     }
+
+    private void deleteScheduleVoteAndVoters(Invitation invitation) {
+        List<ScheduleVote> scheduleVotes = scheduleVoteRepository.findByInvitationId(invitation.getId());
+        scheduleVotes.forEach(scheduleVote -> scheduleVoterRepository.deleteByScheduleVote(scheduleVote));
+        scheduleVoteRepository.deleteAllByInvitation(invitation);
+    }
+
 
     private boolean checkDuplicateScheduleNickname(Invitation invitation, String nickname) {
         return scheduleVoterRepository.existsByInvitationIdAndNickname(invitation.getId(), nickname);


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
-  회원 탈퇴 및 후기 알림 API 구현, 일정 확정 시 `scheduleVote` 관련 데이터 삭제 로직 추가했습니다.


## 💬리뷰 요구사항(선택)
> 리뷰어가 신경써서 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 회원 탈퇴 시 기존의 회원이 작성한 초대장, 후기, 투표 전적이 남아있어야 해서 user의 id, nickname과 기타 enum 타입 데이터를 제외하고 단방향 암호화 방식으로 데이터를 처리했습니다.
- 후기 작성 가능 초대장 목록 조회 시, 받은 초대장이 많아질 경우를 대비해 API 호출 날짜 기준으로 2주 전 데이터만 조회하도록 구현했습니다. 추후 개선할 필요가 있으면 다시 수정하겠습니다!


## ✅Check
- [x] 각 기능에 대한 테스트
- [x] label
- [x] develop branch pull



## #️⃣연관된 이슈
> ex) #이슈번호
- resolve #29 
- resolve #30 
- resolve #32 


## 💡References(선택)
> 작업하면서 참고한 레퍼런스가 있다면 첨부해주세요
- 
