### PR TITLE
[FEAT] 임시 저장된 초대장 조회 기능 구현

### DIFF
--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -130,7 +130,21 @@ public class InvitationController {
 
         return invitationService.saveReceivedInvitation(saveInvitationReq, userPrincipal);
     }
+    @Operation(summary = "임시저장된 초대장 조회", description = "임시저장된 초대장의 id를 통해 초대장의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "임시 저장된 초대장 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = CompletedInvitationRes.class))}),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "404", description = "임시 저장된 초대장을 찾을 수 없음", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @GetMapping("/temp/{invitationId}")
+    public ResponseEntity<?> getTemporaryInvitation(
+            @Parameter(description = "조회할 임시 저장된 초대장의 ID", required = true) @PathVariable Long invitationId,
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
+    ) {
 
+        return invitationService.getInvitation(invitationId, userPrincipal, true);
+    }
     @Operation(summary = "완성된 초대장 조회", description = "완성된 초대장의 id를 통해 초대장의 상세 정보를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "완성된 초대장 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = CompletedInvitationRes.class))}),
@@ -143,7 +157,7 @@ public class InvitationController {
             @Parameter(description = "Accesstoken을 입력해주세요.", required = false) @CurrentUser UserPrincipal userPrincipal
     ) {
 
-        return invitationService.getCompletedInvitation(invitationId, userPrincipal);
+        return invitationService.getInvitation(invitationId, userPrincipal, false);
     }
 
     @Operation(summary = "나의 초대장 목록 조회", description = "작성 중인 초대장, 보낸 초대장 3개, 받은 초대장 3개를 조회합니다.")

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -57,7 +57,7 @@ public class InvitationController {
             @ApiResponse(responseCode = "201", description = "초대장이 성공적으로 임시 저장되었습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(example = "{\"invitationId\": 5, \"message\": \"초대장이 임시 저장되었습니다.\"}"))}),
             @ApiResponse(responseCode = "404", description = "임시저장된 초대장이 유효하지 않습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
-    @PostMapping(value = "/save-temporary")
+    @PostMapping(value = "/temporary")
     public ResponseEntity<?> saveTemporaryInvitation(
             @Parameter(description = "초대장에 들어갈 데이터를 넣어주세요. Schemas의 InvitationReq를 참고해주세요.", required = true) @RequestPart("invitation") @Valid InvitationReq invitationReq,
             @Parameter(description = "초대장 카드 이미지를 넣어주세요.", required = false ) @RequestPart(value = "cardImage", required = false) MultipartFile cardImage,
@@ -146,7 +146,7 @@ public class InvitationController {
             @ApiResponse(responseCode = "404", description = "임시 저장된 초대장을 찾을 수 없음", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "400", description = "잘못된 요청", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
     })
-    @GetMapping("/temp/{invitationId}")
+    @GetMapping("/temporary/{invitationId}")
     public ResponseEntity<?> getTemporaryInvitation(
             @Parameter(description = "조회할 임시 저장된 초대장의 ID", required = true) @PathVariable Long invitationId,
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -40,23 +40,33 @@ public class InvitationController {
     private final InvitationService invitationService;
     private final FeedbackService feedbackService;
 
-    @Operation(summary = "초대장 작성 완료", description = "임시저장된 초대장 혹은 새로운 초대장 작성을 완료합니다.")
+    @Operation(summary = "초대장 작성 완료", description = "임시저장된 초대장 혹은 새로운 초대장 작성을 완료합니다.(임시저장된 초대장이 있을 경우에만 invitationId가 존재합니다.)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "초대장이 성공적으로 작성되었습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(example = "{\"invitationId\": 5, \"message\": \"초대장 작성을 완료하였습니다.\"}"))}),
+            @ApiResponse(responseCode = "404", description = "임시저장된 초대장이 유효하지 않습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
     @PostMapping
     public ResponseEntity<?> createInvitation(
             @Parameter(description = "초대장에 들어갈 데이터를 넣어주세요. Schemas의 InvitationReq를 참고해주세요.", required = true) @RequestPart("invitation")@Valid InvitationReq invitationReq,
             @Parameter(description = "초대장 카드 이미지를 넣어주세요.", required = true ) @RequestPart(value = "cardImage", required = true) MultipartFile cardImage,
             @Parameter(description = "초대장에 들어갈 사진 목록을 넣어주세요.", required = false) @RequestPart(value = "photoImages", required = false) List<MultipartFile> photoImages,
-            @Parameter(description = "Accesstoken을 입력해주세요.", required = false) @CurrentUser UserPrincipal userPrincipal){
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = false) @CurrentUser UserPrincipal userPrincipal
+    ){
 
         return invitationService.publishInvitation(invitationReq, cardImage, photoImages, userPrincipal);
     }
     @Operation(summary = "초대장 임시 저장", description = "임시저장된 초대장 혹은 새로운 초대장을 임시저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "초대장이 성공적으로 임시 저장되었습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(example = "{\"invitationId\": 5, \"message\": \"초대장이 임시 저장되었습니다.\"}"))}),
+            @ApiResponse(responseCode = "404", description = "임시저장된 초대장이 유효하지 않습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
     @PostMapping(value = "/save-temporary")
     public ResponseEntity<?> saveTemporaryInvitation(
             @Parameter(description = "초대장에 들어갈 데이터를 넣어주세요. Schemas의 InvitationReq를 참고해주세요.", required = true) @RequestPart("invitation") @Valid InvitationReq invitationReq,
             @Parameter(description = "초대장 카드 이미지를 넣어주세요.", required = false ) @RequestPart(value = "cardImage", required = false) MultipartFile cardImage,
             @Parameter(description = "초대장에 들어갈 사진 목록을 넣어주세요.", required = false) @RequestPart(value = "photoImages", required = false) List<MultipartFile> photoImages,
-            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal) {
+            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
+    ) {
 
         return invitationService.saveTemporaryInvitation(invitationReq, cardImage, photoImages, userPrincipal);
     }


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- 임시 저장된 초대장이랑 완성된 초대장 조회 로직을 통합했습니다.
- 기존 service에 존재하는 메서드 이름을 getCompletedInvitation -> getInvitation으로 변경하였고 메서드 내에 임시저장된 초대장 조회시 검증로직을 추가하였습니다.
- api는 임시저장된 초대장이랑 완성된 초대장 두개이며, 각각 공통 메서드인 getInvitation을 호출합니다.



## 💬리뷰 요구사항(선택)
> 리뷰어가 신경써서 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-


## ✅Check
- [x] 각 기능에 대한 테스트
- [x] label
- [x] develop branch pull



## #️⃣연관된 이슈
> ex) #이슈번호
- resolve #33 

## 💡References(선택)
> 작업하면서 참고한 레퍼런스가 있다면 첨부해주세요
- 
