### PR TITLE
[REFACTOR] 리프레시 토큰 만료 시 `401 Unauthorized` 응답 반환

### DIFF
--- a/src/main/java/depth/main/wishwesee/domain/auth/controller/AuthController.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/controller/AuthController.java
@@ -29,6 +29,7 @@ public class AuthController {
     @Operation(summary = "토큰 갱신", description = "신규 토큰 갱신을 수행합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "토큰 갱신 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = AuthRes.class) ) } ),
+            @ApiResponse(responseCode = "401", description = "토큰 만료", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = String.class) ) } ),
             @ApiResponse(responseCode = "400", description = "토큰 갱신 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
     @PostMapping(value = "/refresh")

--- a/src/main/java/depth/main/wishwesee/domain/auth/domain/Token.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/domain/Token.java
@@ -20,10 +20,6 @@ public class Token extends BaseEntity {
     @Column(name = "refresh_token", nullable = false)
     private String refreshToken;
 
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
     @Builder
     public Token(String userEmail, String refreshToken) {
         this.userEmail = userEmail;

--- a/src/main/java/depth/main/wishwesee/domain/auth/exception/ExpiredRefreshTokenException.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/exception/ExpiredRefreshTokenException.java
@@ -1,0 +1,7 @@
+package depth.main.wishwesee.domain.auth.exception;
+
+public class ExpiredRefreshTokenException extends RuntimeException {
+    public ExpiredRefreshTokenException() {
+        super("리프레시 토큰이 만료되었습니다.");
+    }
+}

--- a/src/main/java/depth/main/wishwesee/domain/auth/service/AuthService.java
+++ b/src/main/java/depth/main/wishwesee/domain/auth/service/AuthService.java
@@ -52,17 +52,10 @@ public class AuthService {
     }
 
     @Transactional
-    public ResponseEntity<?> signOut(UserPrincipal userPrincipal){
+    public void signOut(UserPrincipal userPrincipal){
         Token token = tokenRepository.findByUserEmail(userPrincipal.getEmail())
                 .orElseThrow(InvalidTokenException::new);
-
         tokenRepository.delete(token);
-
-        ApiResponse apiResponse = ApiResponse.builder()
-                .check(true)
-                .information("유저가 로그아웃 되었습니다.")
-                .build();
-        return ResponseEntity.ok(apiResponse);
     }
 
     private boolean valid(String refreshToken){


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- 리프레시 토큰 만료 시 `401 Unauthorized` 응답 반환하도록 코드를 변경했습니다.


## 💬리뷰 요구사항(선택)
> 리뷰어가 신경써서 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 401 응답을 반환하는 이유는 사용자에게 재로그인을 요청하기 위함입니다!


## ✅Check
- [x] 각 기능에 대한 테스트
- [x] label
- [x] develop branch pull



## #️⃣연관된 이슈
> ex) #이슈번호
-


## 💡References(선택)
> 작업하면서 참고한 레퍼런스가 있다면 첨부해주세요
- 
