### PR TITLE
[REFACTOR] 초대장 접근 접근 시 사용 ID 방식 개선

### DIFF
--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -157,34 +157,34 @@ public class InvitationController {
 
         return invitationService.saveReceivedInvitation(saveInvitationReq, userPrincipal);
     }
-    @Operation(summary = "임시저장된 초대장 조회", description = "임시저장된 초대장의 id를 통해 초대장의 상세 정보를 조회합니다.")
+    @Operation(summary = "임시저장된 초대장 조회", description = "임시저장된 초대장의 토큰을 통해 초대장의 상세 정보를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "임시 저장된 초대장 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = InvitationDetailRes.class))}),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "404", description = "임시 저장된 초대장을 찾을 수 없음", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "400", description = "잘못된 요청", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
     })
-    @GetMapping("/temporary/{invitationId}")
+    @GetMapping("/temporary/{invitationToken}")
     public ResponseEntity<?> getTemporaryInvitation(
-            @Parameter(description = "조회할 임시 저장된 초대장의 ID", required = true) @PathVariable Long invitationId,
+            @Parameter(description = "조회할 임시 저장된 초대장의 토큰", required = true) @PathVariable String invitationToken,
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
     ) {
 
-        return invitationService.getInvitation(invitationId, userPrincipal, true);
+        return invitationService.getInvitation(invitationToken, userPrincipal, true);
     }
-    @Operation(summary = "완성된 초대장 조회", description = "완성된 초대장의 id를 통해 초대장의 상세 정보를 조회합니다.")
+    @Operation(summary = "완성된 초대장 조회", description = "완성된 초대장의 토큰을 통해 초대장의 상세 정보를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "완성된 초대장 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = InvitationDetailRes.class))}),
             @ApiResponse(responseCode = "404", description = "초대장을 찾을 수 없음", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "400", description = "잘못된 요청", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
     })
-    @GetMapping("/{invitationId}")
+    @GetMapping("/{invitationToken}")
     public ResponseEntity<?> getCompletedInvitation(
-            @Parameter(description = "조회할 완성된 초대장의ID", required = true) @PathVariable Long invitationId,
+            @Parameter(description = "조회할 완성된 초대장의 토큰", required = true) @PathVariable String invitationToken,
             @Parameter(description = "Accesstoken을 입력해주세요.", required = false) @CurrentUser UserPrincipal userPrincipal
     ) {
 
-        return invitationService.getInvitation(invitationId, userPrincipal, false);
+        return invitationService.getInvitation(invitationToken, userPrincipal, false);
     }
 
     @Operation(summary = "나의 초대장 목록 조회", description = "작성 중인 초대장, 보낸 초대장 3개, 받은 초대장 3개를 조회합니다.")
@@ -232,12 +232,12 @@ public class InvitationController {
             @ApiResponse(responseCode = "404", description = "초대장 또는 사용자를 찾을 수 없음"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터 (삭제 권한 없음)")
     })
-    @DeleteMapping("/sent/{invitationId}")
+    @DeleteMapping("/sent/{invitationToken}")
     public ResponseEntity<?> deleteSentInvitation(
-            @Parameter(description = "삭제할 초대장의 ID", required = true) @PathVariable Long invitationId,
+            @Parameter(description = "삭제할 초대장의 토큰", required = true) @PathVariable String invitationToken,
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal) {
 
-        return invitationService.deleteSentInvitation(invitationId, userPrincipal);
+        return invitationService.deleteSentInvitation(invitationToken, userPrincipal);
     }
 
     @Operation(summary = "받은 초대장 삭제", description = "사용자가 받은 초대장을 삭제합니다. 삭제 시 초대장 자체는 삭제되지 않고 사용자의 수신 목록에서만 삭제됩니다.")
@@ -245,12 +245,12 @@ public class InvitationController {
             @ApiResponse(responseCode = "204", description = "성공적으로 삭제됨"),
             @ApiResponse(responseCode = "404", description = "해당 초대장이 존재하지 않거나 수신하지 않음")
     })
-    @DeleteMapping("/received/{invitationId}")
+    @DeleteMapping("/received/{invitationToken}")
     public ResponseEntity<?> deleteReceivedInvitation(
-            @Parameter(description = "삭제할 초대장의 ID", required = true)  @PathVariable Long invitationId,
+            @Parameter(description = "삭제할 초대장의 토큰", required = true)  @PathVariable String invitationToken,
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal) {
 
-        return invitationService.deleteReceivedInvitation(invitationId, userPrincipal);
+        return invitationService.deleteReceivedInvitation(invitationToken, userPrincipal);
     }
 
 

--- a/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/controller/InvitationController.java
@@ -232,12 +232,12 @@ public class InvitationController {
             @ApiResponse(responseCode = "404", description = "초대장 또는 사용자를 찾을 수 없음"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터 (삭제 권한 없음)")
     })
-    @DeleteMapping("/sent/{invitationToken}")
+    @DeleteMapping("/sent/{invitationId}")
     public ResponseEntity<?> deleteSentInvitation(
-            @Parameter(description = "삭제할 초대장의 토큰", required = true) @PathVariable String invitationToken,
+            @Parameter(description = "삭제할 초대장의 토큰", required = true) @PathVariable Long invitationId,
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal) {
 
-        return invitationService.deleteSentInvitation(invitationToken, userPrincipal);
+        return invitationService.deleteSentInvitation(invitationId, userPrincipal);
     }
 
     @Operation(summary = "받은 초대장 삭제", description = "사용자가 받은 초대장을 삭제합니다. 삭제 시 초대장 자체는 삭제되지 않고 사용자의 수신 목록에서만 삭제됩니다.")
@@ -245,12 +245,12 @@ public class InvitationController {
             @ApiResponse(responseCode = "204", description = "성공적으로 삭제됨"),
             @ApiResponse(responseCode = "404", description = "해당 초대장이 존재하지 않거나 수신하지 않음")
     })
-    @DeleteMapping("/received/{invitationToken}")
+    @DeleteMapping("/received/{invitationId}")
     public ResponseEntity<?> deleteReceivedInvitation(
-            @Parameter(description = "삭제할 초대장의 토큰", required = true)  @PathVariable String invitationToken,
+            @Parameter(description = "삭제할 초대장의 토큰", required = true)  @PathVariable Long invitationId,
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal) {
 
-        return invitationService.deleteReceivedInvitation(invitationToken, userPrincipal);
+        return invitationService.deleteReceivedInvitation(invitationId, userPrincipal);
     }
 
 

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/Invitation.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/Invitation.java
@@ -20,7 +20,7 @@ public class Invitation extends BaseEntity{
     private Long id;
 
     @Column(unique = true)
-    private String invitationToken; // 초대장 UUID
+    private String token; // 초대장 UUID
 
     private String title;
 
@@ -72,13 +72,13 @@ public class Invitation extends BaseEntity{
 
 
     @Builder
-    public Invitation(String invitationToken, String title, String cardImage, boolean tempSaved, LocalDate startDate,
+    public Invitation(String token, String title, String cardImage, boolean tempSaved, LocalDate startDate,
                       LocalTime startTime, LocalDate endDate, LocalTime endTime, String userLocation, String location,
                       String address, String mapLink, double latitude, double longitude,
                       int mapViewType, LocalDate voteDeadline, boolean attendanceSurveyEnabled,
                       boolean scheduleVoteMultiple, boolean scheduleVoteClosed, boolean attendanceSurveyClosed, User sender){
 
-        this.invitationToken = invitationToken;
+        this.token = token;
         this.title = title;
         this.cardImage = cardImage;
         this.tempSaved = tempSaved;

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/Invitation.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/Invitation.java
@@ -19,6 +19,9 @@ public class Invitation extends BaseEntity{
     @Column(name = "invitation_id")
     private Long id;
 
+    @Column(unique = true)
+    private String invitationToken; // 초대장 UUID
+
     private String title;
 
     private String cardImage;
@@ -69,12 +72,13 @@ public class Invitation extends BaseEntity{
 
 
     @Builder
-    public Invitation(String title, String cardImage, boolean tempSaved, LocalDate startDate,
+    public Invitation(String invitationToken, String title, String cardImage, boolean tempSaved, LocalDate startDate,
                       LocalTime startTime, LocalDate endDate, LocalTime endTime, String userLocation, String location,
                       String address, String mapLink, double latitude, double longitude,
                       int mapViewType, LocalDate voteDeadline, boolean attendanceSurveyEnabled,
                       boolean scheduleVoteMultiple, boolean scheduleVoteClosed, boolean attendanceSurveyClosed, User sender){
 
+        this.invitationToken = invitationToken;
         this.title = title;
         this.cardImage = cardImage;
         this.tempSaved = tempSaved;

--- a/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/InvitationRepository.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/domain/repository/InvitationRepository.java
@@ -21,4 +21,5 @@ public interface InvitationRepository extends JpaRepository<Invitation, Long> {
     @Query("SELECT i FROM Invitation i WHERE i.sender = :user AND FUNCTION('YEAR', i.createdDate) = :year AND i.tempSaved = false ORDER BY i.modifiedDate DESC")
     List<Invitation> findBySenderAndYearAndTempSavedFalse(@Param("user") User user, @Param("year") int year); // 연도별 보낸 초대장
 
+    Optional<Invitation> findByInvitationToken(String invitationToken);
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/InvitationDetailRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/InvitationDetailRes.java
@@ -17,6 +17,9 @@ public class InvitationDetailRes {
     @Schema(description = "초대장ID", example = "1", type = "Long")
     private Long invitationId;
 
+    @Schema(description = "초대장UUID(고유 식별자)", example = "abcd-1234-efgh-5678", type = "String")
+    private String invitationToken;
+
     @Schema(description = "로그인한 사용자 여부", example = "true", type = "boolean")
     private boolean isLoggedIn;
 
@@ -95,12 +98,13 @@ public class InvitationDetailRes {
     private List<BlockRes> blocks; // 블록 리스트
 
     @Builder
-    public InvitationDetailRes(Long invitationId, boolean isLoggedIn, boolean isOwner, boolean alreadySaved, boolean canWriteFeedback,String cardImage, String title, LocalDate startDate,
+    public InvitationDetailRes(Long invitationId, String invitationToken, boolean isLoggedIn, boolean isOwner, boolean alreadySaved, boolean canWriteFeedback,String cardImage, String title, LocalDate startDate,
                                LocalTime startTime, LocalDate endDate, LocalTime endTime, LocalDate voteDeadline, boolean hasScheduleVote, boolean scheduleVoteMultiple,
                                List<ScheduleVoteRes> scheduleVotes, boolean scheduleVoteClosed, int mapViewType, String userLocation, String location, String address,
                                String mapLink, double latitude, double longitude, List<BlockRes> blocks, boolean attendanceSurveyEnabled) {
 
         this.invitationId = invitationId;
+        this.invitationToken = invitationToken;
         this.title = title;
         this.cardImage = cardImage;
         this.startDate = startDate;

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/MyInvitationOverViewRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/MyInvitationOverViewRes.java
@@ -39,6 +39,9 @@ public class MyInvitationOverViewRes {
         @Schema(description = "초대장ID", example = "5", type = "Long")
         private Long invitationId;
 
+        @Schema(description = "초대장 토큰", example = "328d5c51-79b4-4ae3-860b-17cbe178f345", type = "String")
+        private String invitationToken;
+
         @Schema(description = "초대장 카드 이미지 URL", example = "https://wishwesee-s3-image-bucket.s3.amazonaws.com/3f78b60d-c3b5-46db-aab2-9f8245ad7b35.jpg", type = "String")
         private String cardImage;
 
@@ -50,8 +53,9 @@ public class MyInvitationOverViewRes {
         private LocalDateTime date;
 
         @Builder
-        InvitationRes(Long invitationId, String cardImage, String title, LocalDateTime date){
+        InvitationRes(Long invitationId, String invitationToken, String cardImage, String title, LocalDateTime date){
             this.invitationId = invitationId;
+            this.invitationToken = invitationToken;
             this.cardImage = cardImage;
             this.title = title;
             this.date = date;

--- a/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/NotificationFeedbackRes.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/dto/response/NotificationFeedbackRes.java
@@ -16,6 +16,9 @@ public class NotificationFeedbackRes {
     @Schema(description = "초대장ID", example = "1", type = "Long")
     private Long invitationId;
 
+    @Schema(description = "초대장 토큰", example = "328d5c51-79b4-4ae3-860b-17cbe178f345", type = "String")
+    private String invitationToken;
+
     @Schema(description = "초대장 제목", example = "크리스마스", type = "String")
     private String title;
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/FeedbackService.java
@@ -175,6 +175,7 @@ public class FeedbackService {
                     if (checkNotificationFeedback(invitation) && !feedbackRepository.existsByInvitationAndUser(invitation, user)) {
                         return NotificationFeedbackRes.builder()
                                 .invitationId(invitation.getId())
+                                .invitationToken(invitation.getToken())
                                 .title(invitation.getTitle())
                                 .build();
                     }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/InvitationService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/InvitationService.java
@@ -344,8 +344,11 @@ public class InvitationService {
             user = findUserByPrincipal(userPrincipal);
         }
 
+        // 초대장 토큰 생성
+        String invitationToken = generateInvitationToken();
+
         return Invitation.builder()
-                .invitationToken(UUID.randomUUID().toString()) // UUID 토큰 자동 생성
+                .invitationToken(invitationToken)
                 .title(invitationReq.getTitle())
                 .cardImage(cardImageUrl)
                 .tempSaved(isTemporary)
@@ -367,6 +370,11 @@ public class InvitationService {
                 .attendanceSurveyClosed(invitationReq.isAttendanceSurveyClosed())
                 .sender(user)
                 .build();
+    }
+
+    // UUID 기반 초대장 토큰 생성 메서드
+    private String generateInvitationToken() {
+        return UUID.randomUUID().toString();
     }
 
     private void updateInvitationDetails(Invitation invitation, InvitationReq invitationReq, MultipartFile cardImage, List<MultipartFile> photoImages) {

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/InvitationService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/InvitationService.java
@@ -69,7 +69,7 @@ public class InvitationService {
                 .body(Map.of(
                         "message", "초대장이 임시 저장되었습니다.",
                         "invitationId", invitation.getId(),
-                        "invitationToken", invitation.getInvitationToken()
+                        "invitationToken", invitation.getToken()
                 ));
 
     }
@@ -83,7 +83,7 @@ public class InvitationService {
                 .body(Map.of(
                         "message", "초대장 작성을 완료하였습니다.",
                         "invitationId", invitation.getId(),
-                        "invitationToken", invitation.getInvitationToken()
+                        "invitationToken", invitation.getToken()
                 ));
 
     }
@@ -348,7 +348,7 @@ public class InvitationService {
         String invitationToken = generateInvitationToken();
 
         return Invitation.builder()
-                .invitationToken(invitationToken)
+                .token(invitationToken)
                 .title(invitationReq.getTitle())
                 .cardImage(cardImageUrl)
                 .tempSaved(isTemporary)
@@ -574,6 +574,7 @@ public class InvitationService {
         return invitations.stream()
                 .map(invitation -> MyInvitationOverViewRes.InvitationRes.builder()
                         .invitationId(invitation.getId())
+                        .invitationToken(invitation.getToken())
                         .title(invitation.getTitle())
                         .cardImage(invitation.getCardImage())
                         .date(invitation.getCreatedDate())

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/InvitationService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/InvitationService.java
@@ -87,13 +87,231 @@ public class InvitationService {
                 ));
 
     }
+
+    @Transactional
+    public ResponseEntity<?> saveReceivedInvitation(SaveInvitationReq saveInvitationReq, UserPrincipal userPrincipal) {
+        // 현재 사용자 정보 가져오기
+        User receiver = findUserByPrincipal(userPrincipal);
+
+        // 초대장 정보 가져오기
+        Invitation invitation = findInvitationById(saveInvitationReq.getInvitationId());
+
+        // 작성자 본인 확인
+        if(invitation.getSender() != null && invitation.getSender().getId().equals(receiver.getId())){
+            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_PARAMETER, "본인이 작성한 초대장은 저장할 수 없습니다.");
+            return ResponseEntity.badRequest().body(errorResponse);
+        }
+
+        // 중복 확인 (초대장이 이미 저장된 경우)
+        boolean alreadyExists = receivedInvitationRepository.existsByReceiverAndInvitation(receiver, invitation);
+        if (alreadyExists) {
+            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.DUPLICATE_ERROR, "이미 내 목록에 저장된 초대장입니다.");
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+        }
+
+        // 초대장 저장
+        ReceivedInvitation receivedInvitation = ReceivedInvitation.builder()
+                .receiver(receiver)
+                .invitation(invitation)
+                .build();
+
+        receivedInvitationRepository.save(receivedInvitation);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    public ResponseEntity<?> getInvitation(String invitationToken, UserPrincipal userPrincipal, boolean isTemporary) {
+        // 초대장 조회
+        Invitation invitation = findInvitationByToken(invitationToken);
+
+        // 사용자 확인
+        User user = Optional.ofNullable(userPrincipal)
+                .map(principal -> validateUserById(principal.getId()))
+                .orElse(null);
+
+        // 초대장 상태 확인 (임시 저장 여부 및 완성 여부)
+        validateInvitationState(isTemporary, invitation);
+
+        // 작성자 본인 여부 확인
+        boolean isOwner = user == invitation.getSender();
+
+        // 임시 저장된 초대장은 작성자 본인만 접근 가능
+        if(isTemporary && !isOwner){
+            throw new DefaultException(ErrorCode.INVALID_AUTHENTICATION, "작성자 본인만 접근 가능합니다.");
+        }
+
+        // 보관함에 저장 여부 확인(완성된 초대장에서 적용)
+        boolean alreadySaved = user != null && receivedInvitationRepository.existsByReceiverAndInvitation(user, invitation);
+
+        // 초대장의 모든 블록 조회 및 변환
+        List<BlockRes> blockResList = transformBlocks(blockRepository.findByInvitationId(invitation.getId()));
+
+        // 초대장의 투표 정보 조회
+        List<ScheduleVoteRes> scheduleVoteResList = getInvitationScheduleVote(user, invitation);
+
+        // 사용자가 투표했는지 확인
+        boolean hasVoted = user != null && scheduleVoterRepository.existsByInvitationIdAndUser(invitation.getId(), user);
+
+        // 후기 작성 가능 여부
+        boolean canWriteFeedback = feedbackService.checkWritableFeedback(invitation);
+
+        // 응답 DTO 생성
+        InvitationDetailRes response = InvitationDetailRes.builder()
+                .invitationId(invitation.getId())
+                .isOwner(isOwner)
+                .isLoggedIn(user != null)
+                .cardImage(invitation.getCardImage())
+                .title(invitation.getTitle())
+                .startDate(invitation.getStartDate())
+                .startTime(invitation.getStartTime())
+                .endDate(invitation.getEndDate())
+                .endTime(invitation.getEndTime())
+                .voteDeadline(invitation.getVoteDeadline())
+                .scheduleVoteMultiple(invitation.isScheduleVoteMultiple())
+                .hasScheduleVote(hasVoted)
+                .scheduleVotes(scheduleVoteResList)
+                .scheduleVoteClosed(invitation.isScheduleVoteClosed())
+                .mapViewType(invitation.getMapViewType())
+                .userLocation(invitation.getUserLocation())
+                .location(invitation.getLocation())
+                .address(invitation.getAddress())
+                .mapLink(invitation.getMapLink())
+                .latitude(invitation.getLatitude())
+                .longitude(invitation.getLongitude())
+                .blocks(blockResList)
+                .alreadySaved(alreadySaved)
+                .canWriteFeedback(canWriteFeedback)
+                .attendanceSurveyEnabled(invitation.isAttendanceSurveyEnabled())
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+
+    public ResponseEntity<?> getMyInvitations(UserPrincipal userPrincipal) {
+        User user = findUserByPrincipal(userPrincipal);
+
+        // 작성 중인 초대장 조회
+        List<MyInvitationOverViewRes.InvitationRes> draftingInvitations = convertToInvitationRes(
+                invitationRepository.findBySenderAndTempSavedTrue(user)
+        );
+
+        int draftCount = draftingInvitations.size(); //작성중인 초대장 개수
+
+        // 보낸 초대장 최신순 3개 조회
+         List<MyInvitationOverViewRes.InvitationRes> sentInvitations = convertToInvitationRes(
+                 invitationRepository.findTop3BySenderAndTempSavedFalseOrderByModifiedDateDesc(user)
+         );
+
+        // 받은 초대장 최신순 3개
+        List<MyInvitationOverViewRes.InvitationRes> receivedInvitations = convertToInvitationRes(
+                receivedInvitationRepository.findTop3ByReceiverOrderByCreatedDateDesc(user)
+                        .stream()
+                        .map(receivedInvitation -> receivedInvitation.getInvitation())
+                        .toList()
+        );
+
+        MyInvitationOverViewRes myInvitationOverViewRes = MyInvitationOverViewRes.builder()
+                .draftCount(draftCount)
+                .draftingInvitations(draftingInvitations)
+                .sentInvitations(sentInvitations)
+                .receivedInvitations(receivedInvitations)
+                .build();
+
+        return ResponseEntity.ok(myInvitationOverViewRes);
+    }
+
+    public ResponseEntity<?> getSentInvitationByYear(UserPrincipal userPrincipal, int year) {
+        User user = findUserByPrincipal(userPrincipal);
+
+        List<MyInvitationOverViewRes.InvitationRes> sentInvitations = convertToInvitationRes(
+                invitationRepository.findBySenderAndYearAndTempSavedFalse(user, year)
+        );
+
+        // 전체 보낸 초대장 개수
+        int totalSentInvitations = sentInvitations.size();
+
+        return createInvitationListResponse(sentInvitations, totalSentInvitations);
+    }
+
+    public ResponseEntity<?> getReceivedInvitationsByYear(UserPrincipal userPrincipal, int year) {
+        User user = findUserByPrincipal(userPrincipal);
+
+        List<MyInvitationOverViewRes.InvitationRes> receivedInvitations = convertToInvitationRes(
+                receivedInvitationRepository.findByReceiverAndYear(user, year)
+                        .stream()
+                        .map(receivedInvitation -> receivedInvitation.getInvitation())
+                        .toList()
+        );
+
+        // 전체 받은 초대장 총 개수
+        int totalReceivedCount = receivedInvitations.size();
+
+        return createInvitationListResponse(receivedInvitations, totalReceivedCount);
+
+    }
+
+    @Transactional
+    public ResponseEntity<?> deleteSentInvitation(String invitationToken, UserPrincipal userPrincipal) {
+        // 초대장 조회
+        Invitation invitation = findInvitationByToken(invitationToken);
+
+        // 보낸 사람 확인
+        if (!invitation.getSender().getId().equals(userPrincipal.getId())) {
+            throw new DefaultException(ErrorCode.INVALID_AUTHENTICATION, "본인이 보낸 초대장만 삭제할 수 있습니다.");
+        }
+
+        // 관련 데이터 삭제
+        // 1. Feedback 삭제
+        feedbackRepository.deleteByInvitation(invitation);
+
+        // 2. Attendance 삭제
+        attendanceRepository.deleteByInvitation(invitation);
+
+        // 3. ScheduleVote와 연관된 VoterNickname삭제
+        List<ScheduleVote> scheduleVotes = scheduleVoteRepository.findByInvitation(invitation);
+        for(ScheduleVote scheduleVote : scheduleVotes){
+            scheduleVoterRepository.deleteByScheduleVote(scheduleVote);
+        }
+
+        scheduleVoteRepository.deleteByInvitation(invitation);
+
+        // 4. ReceivedInvitation삭제
+        receivedInvitationRepository.deleteByInvitation(invitation);
+
+        // 5. Block 삭제(상속된엔티티포함)
+        blockRepository.deleteByInvitation(invitation);
+
+        // 6. 초대장 삭제
+        invitationRepository.delete(invitation);
+
+        return ResponseEntity.noContent().build();
+
+    }
+    @Transactional
+    public ResponseEntity<?> deleteReceivedInvitation(String invitationToken, UserPrincipal userPrincipal) {
+        // 현재 사용자 조회
+        User receiver = findUserByPrincipal(userPrincipal);
+
+        // 초대장 조회
+        Invitation invitation = findInvitationByToken(invitationToken);
+
+        // 받은 초대장 데이터 조회
+        ReceivedInvitation receivedInvitation = receivedInvitationRepository.findByReceiverAndInvitationId(receiver, invitation.getId())
+                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "해당 초대장이 존재하지 않거나 수신하지 않았습니다."));
+
+        // 받은 초대장에서만 삭제
+        receivedInvitationRepository.delete(receivedInvitation);
+
+        return ResponseEntity.noContent().build();
+
+    }
     private Invitation saveOrUpdateInvitation(InvitationReq invitationReq, MultipartFile cardImage, List<MultipartFile> photoImages, UserPrincipal userPrincipal, boolean isTemporary) {
         Invitation invitation;
 
         if (invitationReq.getInvitationId() != null) {
             // 기존 초대장 수정
-            invitation = invitationRepository.findById(invitationReq.getInvitationId())
-                    .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "해당 초대장이 존재하지 않습니다."));
+            invitation = findInvitationById(invitationReq.getInvitationId());
 
             invitation.updateTempSaved(isTemporary);  // 임시 저장 여부 업데이트
             updateInvitationDetails(invitation, invitationReq, cardImage, photoImages);
@@ -123,8 +341,7 @@ public class InvitationService {
 
         User user = null;
         if(userPrincipal != null){
-            user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND,"사용자를 찾을 수 없습니다"));
+            user = findUserByPrincipal(userPrincipal);
         }
 
         return Invitation.builder()
@@ -272,110 +489,6 @@ public class InvitationService {
             s3Uploader.deleteFile(imageUrl);
         }
     }
-
-    @Transactional
-    public ResponseEntity<?> saveReceivedInvitation(SaveInvitationReq saveInvitationReq, UserPrincipal userPrincipal) {
-        // 현재 사용자 정보 가져오기
-        User receiver = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다."));
-
-        // 초대장 정보 가져오기
-        Invitation invitation = invitationRepository.findById(saveInvitationReq.getInvitationId())
-                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "해당 초대장이 존재하지 않습니다."));
-
-        // 작성자 본인 확인
-        if(invitation.getSender() != null && invitation.getSender().getId().equals(receiver.getId())){
-            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_PARAMETER, "본인이 작성한 초대장은 저장할 수 없습니다.");
-            return ResponseEntity.badRequest().body(errorResponse);
-        }
-
-        // 중복 확인 (초대장이 이미 저장된 경우)
-        boolean alreadyExists = receivedInvitationRepository.existsByReceiverAndInvitation(receiver, invitation);
-        if (alreadyExists) {
-            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.DUPLICATE_ERROR, "이미 내 목록에 저장된 초대장입니다.");
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
-        }
-
-        // 초대장 저장
-        ReceivedInvitation receivedInvitation = ReceivedInvitation.builder()
-                .receiver(receiver)
-                .invitation(invitation)
-                .build();
-        receivedInvitationRepository.save(receivedInvitation);
-
-        return ResponseEntity.noContent().build();
-    }
-
-
-
-    public ResponseEntity<?> getInvitation(String invitationToken, UserPrincipal userPrincipal, boolean isTemporary) {
-        // 초대장 조회
-        Invitation invitation = invitationRepository.findByInvitationToken(invitationToken)
-                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "해당 초대장이 존재하지 않습니다."));
-
-        // 사용자 확인
-        User user = Optional.ofNullable(userPrincipal)
-                .map(principal -> validateUserById(principal.getId()))
-                .orElse(null);
-
-        // 초대장 상태 확인 (임시 저장 여부 및 완성 여부)
-        validateInvitationState(isTemporary, invitation);
-
-        // 작성자 본인 여부 확인
-        boolean isOwner = user == invitation.getSender();
-
-        // 임시 저장된 초대장은 작성자 본인만 접근 가능
-        if(isTemporary && !isOwner){
-            throw new DefaultException(ErrorCode.INVALID_AUTHENTICATION, "작성자 본인만 접근 가능합니다.");
-        }
-
-        // 보관함에 저장 여부 확인(완성된 초대장에서 적용)
-        boolean alreadySaved = user != null && receivedInvitationRepository.existsByReceiverAndInvitation(user, invitation);
-
-        // 초대장의 모든 블록 조회 및 변환
-        List<BlockRes> blockResList = transformBlocks(blockRepository.findByInvitationId(invitation.getId()));
-
-        // 초대장의 투표 정보 조회
-        List<ScheduleVoteRes> scheduleVoteResList = getInvitationScheduleVote(user, invitation);
-
-        // 사용자가 투표했는지 확인
-        boolean hasVoted = user != null && scheduleVoterRepository.existsByInvitationIdAndUser(invitation.getId(), user);
-
-        // 후기 작성 가능 여부
-        boolean canWriteFeedback = feedbackService.checkWritableFeedback(invitation);
-
-        // 응답 DTO 생성
-        InvitationDetailRes response = InvitationDetailRes.builder()
-                .invitationId(invitation.getId())
-                .isOwner(isOwner)
-                .isLoggedIn(user != null)
-                .cardImage(invitation.getCardImage())
-                .title(invitation.getTitle())
-                .startDate(invitation.getStartDate())
-                .startTime(invitation.getStartTime())
-                .endDate(invitation.getEndDate())
-                .endTime(invitation.getEndTime())
-                .voteDeadline(invitation.getVoteDeadline())
-                .scheduleVoteMultiple(invitation.isScheduleVoteMultiple())
-                .hasScheduleVote(hasVoted)
-                .scheduleVotes(scheduleVoteResList)
-                .scheduleVoteClosed(invitation.isScheduleVoteClosed())
-                .mapViewType(invitation.getMapViewType())
-                .userLocation(invitation.getUserLocation())
-                .location(invitation.getLocation())
-                .address(invitation.getAddress())
-                .mapLink(invitation.getMapLink())
-                .latitude(invitation.getLatitude())
-                .longitude(invitation.getLongitude())
-                .blocks(blockResList)
-                .alreadySaved(alreadySaved)
-                .canWriteFeedback(canWriteFeedback)
-                .attendanceSurveyEnabled(invitation.isAttendanceSurveyEnabled())
-                .build();
-
-        return ResponseEntity.ok(response);
-    }
-
     private List<BlockRes> transformBlocks(List<Block> allBlocks) {
         return allBlocks.stream()
                 .map(block -> {
@@ -414,12 +527,6 @@ public class InvitationService {
                 }).toList();
     }
 
-    private void validateInvitationState(boolean isTemporary, Invitation invitation) {
-        if(isTemporary != invitation.isTempSaved()){
-            throw new DefaultException(ErrorCode.NOT_FOUND, "요청한 초대장의 상태가 일치하지 않습니다.");
-        }
-    }
-
     private List<ScheduleVoteRes> getInvitationScheduleVote(User user, Invitation invitation) {
         List<ScheduleVote> scheduleVotes = scheduleVoteRepository.findByInvitationId(invitation.getId());
         return scheduleVotes.stream()
@@ -438,71 +545,20 @@ public class InvitationService {
                 .collect(Collectors.toList());
     }
 
+    // 초대장 상태 확인 메서드
+    private void validateInvitationState(boolean isTemporary, Invitation invitation) {
+        if(isTemporary != invitation.isTempSaved()){
+            throw new DefaultException(ErrorCode.NOT_FOUND, "요청한 초대장의 상태가 일치하지 않습니다.");
+        }
+    }
 
-    public ResponseEntity<?> getMyInvitations(UserPrincipal userPrincipal) {
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND,"사용자를 찾을 수 없습니다"));
-
-        // 작성 중인 초대장 조회
-        List<MyInvitationOverViewRes.InvitationRes> draftingInvitations = convertToInvitationRes(
-                invitationRepository.findBySenderAndTempSavedTrue(user)
-        );
-
-        int draftCount = draftingInvitations.size(); //작성중인 초대장 개수
-
-        // 보낸 초대장 최신순 3개 조회
-         List<MyInvitationOverViewRes.InvitationRes> sentInvitations = convertToInvitationRes(
-                 invitationRepository.findTop3BySenderAndTempSavedFalseOrderByModifiedDateDesc(user)
-         );
-
-        // 받은 초대장 최신순 3개
-        List<MyInvitationOverViewRes.InvitationRes> receivedInvitations = convertToInvitationRes(
-                receivedInvitationRepository.findTop3ByReceiverOrderByCreatedDateDesc(user)
-                        .stream()
-                        .map(receivedInvitation -> receivedInvitation.getInvitation())
-                        .toList()
-        );
-
-        MyInvitationOverViewRes myInvitationOverViewRes = MyInvitationOverViewRes.builder()
-                .draftCount(draftCount)
-                .draftingInvitations(draftingInvitations)
-                .sentInvitations(sentInvitations)
-                .receivedInvitations(receivedInvitations)
+    // InvitationListRes 응답 생성 메서드
+    private ResponseEntity<InvitationListRes> createInvitationListResponse(List<MyInvitationOverViewRes.InvitationRes> invitations, int totalCount) {
+        InvitationListRes response = InvitationListRes.builder()
+                .totalInvitations(totalCount)
+                .invitations(invitations)
                 .build();
-
-        return ResponseEntity.ok(myInvitationOverViewRes);
-    }
-
-    public ResponseEntity<?> getSentInvitationByYear(UserPrincipal userPrincipal, int year) {
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다"));
-
-        List<MyInvitationOverViewRes.InvitationRes> sentInvitations = convertToInvitationRes(
-                invitationRepository.findBySenderAndYearAndTempSavedFalse(user, year)
-        );
-
-        // 전체 보낸 초대장 개수
-        int totalSentInvitations = sentInvitations.size();
-
-        return createInvitationListResponse(sentInvitations, totalSentInvitations);
-    }
-
-    public ResponseEntity<?> getReceivedInvitationsByYear(UserPrincipal userPrincipal, int year) {
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다"));
-
-        List<MyInvitationOverViewRes.InvitationRes> receivedInvitations = convertToInvitationRes(
-                receivedInvitationRepository.findByReceiverAndYear(user, year)
-                        .stream()
-                        .map(receivedInvitation -> receivedInvitation.getInvitation())
-                        .toList()
-        );
-
-        // 전체 받은 초대장 총 개수
-        int totalReceivedCount = receivedInvitations.size();
-
-        return createInvitationListResponse(receivedInvitations, totalReceivedCount);
-
+        return ResponseEntity.ok(response);
     }
 
     // 초대장 리스트 반환 메서드
@@ -517,77 +573,29 @@ public class InvitationService {
                 .toList();
     }
 
-    // InvitationListRes 응답 생성 메서드
-    private ResponseEntity<InvitationListRes> createInvitationListResponse(List<MyInvitationOverViewRes.InvitationRes> invitations, int totalCount) {
-        InvitationListRes response = InvitationListRes.builder()
-                .totalInvitations(totalCount)
-                .invitations(invitations)
-                .build();
-        return ResponseEntity.ok(response);
-    }
-    @Transactional
-    public ResponseEntity<?> deleteSentInvitation(String invitationToken, UserPrincipal userPrincipal) {
-        // 초대장 조회
-        Invitation invitation = invitationRepository.findByInvitationToken(invitationToken)
-                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "해당 초대장이 존재하지 않습니다."));
-
-        // 보낸 사람 확인
-        if (!invitation.getSender().getId().equals(userPrincipal.getId())) {
-            throw new DefaultException(ErrorCode.INVALID_AUTHENTICATION, "본인이 보낸 초대장만 삭제할 수 있습니다.");
-        }
-
-        // 관련 데이터 삭제
-        // 1. Feedback 삭제
-        feedbackRepository.deleteByInvitation(invitation);
-
-        // 2. Attendance 삭제
-        attendanceRepository.deleteByInvitation(invitation);
-
-        // 3. ScheduleVote와 연관된 VoterNickname삭제
-        List<ScheduleVote> scheduleVotes = scheduleVoteRepository.findByInvitation(invitation);
-        for(ScheduleVote scheduleVote : scheduleVotes){
-            scheduleVoterRepository.deleteByScheduleVote(scheduleVote);
-        }
-
-        scheduleVoteRepository.deleteByInvitation(invitation);
-
-        // 4. ReceivedInvitation삭제
-        receivedInvitationRepository.deleteByInvitation(invitation);
-
-        // 5. Block 삭제(상속된엔티티포함)
-        blockRepository.deleteByInvitation(invitation);
-
-        // 6. 초대장 삭제
-        invitationRepository.delete(invitation);
-
-        return ResponseEntity.noContent().build();
-
-    }
-    @Transactional
-    public ResponseEntity<?> deleteReceivedInvitation(String invitationToken, UserPrincipal userPrincipal) {
-        // 현재 사용자 조회
-        User receiver = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다."));
-
-        // 초대장 조회
-        Invitation invitation = invitationRepository.findByInvitationToken(invitationToken)
-                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "해당 초대장이 존재하지 않습니다."));
-
-        // 받은 초대장 데이터 조회
-        ReceivedInvitation receivedInvitation = receivedInvitationRepository.findByReceiverAndInvitationId(receiver, invitation.getId())
-                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "해당 초대장이 존재하지 않거나 수신하지 않았습니다."));
-
-        // 받은 초대장에서만 삭제
-        receivedInvitationRepository.delete(receivedInvitation);
-
-        return ResponseEntity.noContent().build();
-
-    }
-
+    // ID로 사용자 조회 및 존재 여부 검증
     private User validateUserById(Long userId) {
         Optional<User> userOptional = userRepository.findById(userId);
         DefaultAssert.isOptionalPresent(userOptional, "사용자가 존재하지 않습니다.");
         return userOptional.get();
+    }
+
+    // 인증된 사용자 정보로 사용자 조회
+    private User findUserByPrincipal(UserPrincipal userPrincipal) {
+        return userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+    }
+
+    // UUID 토큰으로 초대장 조회
+    private Invitation findInvitationByToken(String token) {
+        return invitationRepository.findByInvitationToken(token)
+                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "해당 초대장이 존재하지 않습니다."));
+    }
+
+    // ID로 초대장 조회
+    private Invitation findInvitationById(Long id) {
+        return invitationRepository.findById(id)
+                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND, "해당 초대장이 존재하지 않습니다."));
     }
 
 }

--- a/src/main/java/depth/main/wishwesee/domain/invitation/service/InvitationService.java
+++ b/src/main/java/depth/main/wishwesee/domain/invitation/service/InvitationService.java
@@ -252,9 +252,9 @@ public class InvitationService {
     }
 
     @Transactional
-    public ResponseEntity<?> deleteSentInvitation(String invitationToken, UserPrincipal userPrincipal) {
+    public ResponseEntity<?> deleteSentInvitation(Long invitationId, UserPrincipal userPrincipal) {
         // 초대장 조회
-        Invitation invitation = findInvitationByToken(invitationToken);
+        Invitation invitation = findInvitationById(invitationId);
 
         // 보낸 사람 확인
         if (!invitation.getSender().getId().equals(userPrincipal.getId())) {
@@ -289,12 +289,12 @@ public class InvitationService {
 
     }
     @Transactional
-    public ResponseEntity<?> deleteReceivedInvitation(String invitationToken, UserPrincipal userPrincipal) {
+    public ResponseEntity<?> deleteReceivedInvitation(Long invitationId, UserPrincipal userPrincipal) {
         // 현재 사용자 조회
         User receiver = findUserByPrincipal(userPrincipal);
 
         // 초대장 조회
-        Invitation invitation = findInvitationByToken(invitationToken);
+        Invitation invitation = findInvitationById(invitationId);
 
         // 받은 초대장 데이터 조회
         ReceivedInvitation receivedInvitation = receivedInvitationRepository.findByReceiverAndInvitationId(receiver, invitation.getId())

--- a/src/main/java/depth/main/wishwesee/domain/map/service/MapService.java
+++ b/src/main/java/depth/main/wishwesee/domain/map/service/MapService.java
@@ -37,69 +37,82 @@ public class MapService {
                 return ResponseEntity.badRequest().body("올바른 검색어를 입력하세요.");
             }
 
-            List<MapLocationRes> places = new ArrayList<>();
-            String encodedQuery = java.net.URLEncoder.encode(name, "UTF-8");
-            int start = 1; // 페이징 시작
-            int display = 5; // 한 번에 가져올 최대 결과 수
-
-            String apiUrlWithParams = localApiUrl + "?query=" + encodedQuery + "&display=" + display + "&start=" + start;
-
-            // API 요청
-            URL url = new URL(apiUrlWithParams);
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("GET");
-            connection.setRequestProperty("X-Naver-Client-Id", localClientId);
-            connection.setRequestProperty("X-Naver-Client-Secret", localClientSecret);
-
-            int responseCode = connection.getResponseCode();
-            if (responseCode != HttpURLConnection.HTTP_OK) {
-                throw new RuntimeException("Local API 호출 실패 - 응답 코드: " + responseCode);
+            // 1차 검색 (원본 입력)
+            List<MapLocationRes> result = searchFromNaverAPI(name);
+            if (!result.isEmpty()) {
+                return ResponseEntity.ok(result);
             }
 
-            BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-            StringBuilder response = new StringBuilder();
-            String line;
-            while ((line = reader.readLine()) != null) {
-                response.append(line);
-            }
-            reader.close();
-
-            JSONObject jsonResponse = new JSONObject(response.toString());
-            JSONArray itemsArray = jsonResponse.getJSONArray("items");
-
-            for (int i = 0; i < itemsArray.length(); i++) {
-                JSONObject place = itemsArray.getJSONObject(i);
-
-                // HTML 태그 제거
-                String location = place.getString("title").replaceAll("<.*?>", "");
-                String address = place.getString("roadAddress");
-
-                // 위도와 경도 변환
-                double latitude = Double.parseDouble(place.getString("mapy")) / 1e6;
-                double longitude = Double.parseDouble(place.getString("mapx")) / 1e6;
-
-                // 지도 링크 생성
-                String encodedAddress = java.net.URLEncoder.encode(address, "UTF-8");
-                String mapLink = "https://map.naver.com/v5/search/" + encodedAddress;
-
-                places.add(MapLocationRes.builder()
-                        .location(location)
-                        .address(address)
-                        .mapLink(mapLink)
-                        .latitude(latitude)
-                        .longitude(longitude)
-                        .build());
+            // 2차 검색 (공백 제거 후 재검색)
+            String cleanedName = name.replaceAll("\\s+", ""); // 모든 공백 제거
+            if (!cleanedName.equals(name)) { // 공백 제거로 변화가 있을 때만 재검색
+                List<MapLocationRes> cleanedResult = searchFromNaverAPI(cleanedName);
+                return ResponseEntity.ok(cleanedResult);
             }
 
-            // 검색 결과 정렬 (가나다순)
-            Collator collator = Collator.getInstance(Locale.KOREA);
-            places.sort((a, b) -> collator.compare(a.getLocation(), b.getLocation()));
+            // 결과 없음
+            return ResponseEntity.ok(Collections.emptyList());
 
-            return ResponseEntity.ok(places);
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(500).body("장소 검색 중 오류 발생: " + e.getMessage());
         }
+    }
+
+    private List<MapLocationRes> searchFromNaverAPI(String query) throws Exception {
+        List<MapLocationRes> places = new ArrayList<>();
+        String encodedQuery = java.net.URLEncoder.encode(query, "UTF-8");
+        int start = 1;
+        int display = 5;
+
+        String apiUrlWithParams = localApiUrl + "?query=" + encodedQuery + "&display=" + display + "&start=" + start;
+
+        URL url = new URL(apiUrlWithParams);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("GET");
+        connection.setRequestProperty("X-Naver-Client-Id", localClientId);
+        connection.setRequestProperty("X-Naver-Client-Secret", localClientSecret);
+
+        if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+            throw new RuntimeException("Local API 호출 실패 - 응답 코드: " + connection.getResponseCode());
+        }
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        StringBuilder response = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            response.append(line);
+        }
+        reader.close();
+
+        JSONObject jsonResponse = new JSONObject(response.toString());
+        JSONArray itemsArray = jsonResponse.getJSONArray("items");
+
+        for (int i = 0; i < itemsArray.length(); i++) {
+            JSONObject place = itemsArray.getJSONObject(i);
+            String location = place.getString("title").replaceAll("<.*?>", "");
+            String address = place.optString("roadAddress", "");
+
+            double latitude = Double.parseDouble(place.getString("mapy")) / 1e6;
+            double longitude = Double.parseDouble(place.getString("mapx")) / 1e6;
+
+            String encodedAddress = java.net.URLEncoder.encode(address, "UTF-8");
+            String mapLink = "https://map.naver.com/v5/search/" + encodedAddress;
+
+            places.add(MapLocationRes.builder()
+                    .location(location)
+                    .address(address)
+                    .mapLink(mapLink)
+                    .latitude(latitude)
+                    .longitude(longitude)
+                    .build());
+        }
+
+        // 가나다 순 정렬
+        Collator collator = Collator.getInstance(Locale.KOREA);
+        places.sort((a, b) -> collator.compare(a.getLocation(), b.getLocation()));
+
+        return places;
     }
 
 


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- 초대장 접근 시 기존에는 invitationID로 접근했지만, 초대장 작성할 때 생성되는 UUID형태의 invitationToken을 통해 접근하도록 개선하였습니다.
- 조회 및 검증 메서드를 (findUserByPrincipal, findInvitationByToken 등) 별도로 추출하였습니다.
- 비즈니스로직 메서드 -> 내부처리 메서드 -> 조회 및 검증 메서드 순으로 메서드 순서를 변경하였습니다.

## 💬리뷰 요구사항(선택)
> 리뷰어가 신경써서 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- URL에 invitationId가 드러나는 곳을 모두 변경해야 될 것 같아서 우선 제가 구현한 api를 변경하였습니다. 
-보낸 초대장 삭제
-받은 초대장 삭제
-완성된 초대장 조회
-임시저장된 초대장 조회

## ✅Check
- [x] 각 기능에 대한 테스트
- [x] label
- [x] develop branch pull



## #️⃣연관된 이슈
> ex) #이슈번호
- resolve #78 


## 💡References(선택)
> 작업하면서 참고한 레퍼런스가 있다면 첨부해주세요
- 
